### PR TITLE
[frontend] Close issue

### DIFF
--- a/client/src/actions/issues.js
+++ b/client/src/actions/issues.js
@@ -6,6 +6,11 @@ export const createIssue = (id, text, alternatives, voteDemand) => ({
   voteDemand,
 });
 
+export const closeIssue = data => ({
+  type: 'server/CLOSE_ISSUE',
+  data,
+});
+
 export const sendVote = (id, alternative, voter) => ({
   type: 'SEND_VOTE',
   id,

--- a/client/src/components/AdminHome.js
+++ b/client/src/components/AdminHome.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import ActiveIssue from '../containers/ActiveIssue';
+import AdminIssueContainer from '../containers/AdminIssueContainer';
 import AdminPanelAlternativesContainer from '../containers/AdminPanelAlternativesContainer';
 
 
 const AdminHome = () => (
   <div>
-    <ActiveIssue className="fefef" />
+    <AdminIssueContainer className="fefef" />
     <AdminPanelAlternativesContainer />
   </div>
 );

--- a/client/src/components/Issue.js
+++ b/client/src/components/Issue.js
@@ -1,19 +1,19 @@
 import React from 'react';
 import '../css/Issue.css';
 
-const Issue = ({ issue }) => (
+const Issue = ({ text }) => (
   <div className="Issue">
     <h2 className="Issue-heading">Aktiv sak</h2>
-    <p>{issue}</p>
+    <p>{text}</p>
   </div>
 );
 
 Issue.defaultProps = {
-  issue: undefined,
+  text: '',
 };
 
 Issue.propTypes = {
-  issue: React.PropTypes.string,
+  text: React.PropTypes.string,
 };
 
 export default Issue;

--- a/client/src/components/IssueAdmin.js
+++ b/client/src/components/IssueAdmin.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import Button from './Button';
+import ActiveIssue from '../containers/ActiveIssue';
+
+const IssueAdmin = ({ issue, closeIssue }) => (
+  <div>
+    <ActiveIssue />
+    <Button onClick={() => closeIssue(issue)}>Avslutt sak</Button>
+  </div>
+);
+
+IssueAdmin.defaultProps = {
+  issue: {
+    _id: '-1',
+    text: 'Ingen aktiv sak.',
+  },
+};
+
+IssueAdmin.propTypes = {
+  issue: React.PropTypes.shape({
+    _id: React.PropTypes.string,
+    name: React.PropTypes.string,
+  }),
+  closeIssue: React.PropTypes.func.isRequired,
+};
+
+export default IssueAdmin;

--- a/client/src/components/IssueAdmin.js
+++ b/client/src/components/IssueAdmin.js
@@ -2,25 +2,14 @@ import React from 'react';
 import Button from './Button';
 import ActiveIssue from '../containers/ActiveIssue';
 
-const IssueAdmin = ({ issue, closeIssue }) => (
+const IssueAdmin = ({ closeIssue }) => (
   <div>
     <ActiveIssue />
-    <Button onClick={() => closeIssue(issue)}>Avslutt sak</Button>
+    <Button onClick={closeIssue}>Avslutt sak</Button>
   </div>
 );
 
-IssueAdmin.defaultProps = {
-  issue: {
-    _id: '-1',
-    text: 'Ingen aktiv sak.',
-  },
-};
-
 IssueAdmin.propTypes = {
-  issue: React.PropTypes.shape({
-    _id: React.PropTypes.string,
-    name: React.PropTypes.string,
-  }),
   closeIssue: React.PropTypes.func.isRequired,
 };
 

--- a/client/src/containers/ActiveIssue.js
+++ b/client/src/containers/ActiveIssue.js
@@ -1,9 +1,9 @@
 import { connect } from 'react-redux';
 import Issue from '../components/Issue';
-import { getIssue } from '../selectors/issues';
+import { getIssueText } from '../selectors/issues';
 
 const mapStateToProps = state => ({
-  issue: getIssue(state),
+  text: getIssueText(state),
 });
 
 export default connect(

--- a/client/src/containers/ActiveIssue.js
+++ b/client/src/containers/ActiveIssue.js
@@ -1,10 +1,9 @@
 import { connect } from 'react-redux';
 import Issue from '../components/Issue';
+import { getIssue } from '../selectors/issues';
 
 const mapStateToProps = state => ({
-  issue: state.issues.length ? // Issues may not be added yet.
-    state.issues[state.issues.length - 1].text :
-    undefined,
+  issue: getIssue(state),
 });
 
 export default connect(

--- a/client/src/containers/AdminIssueContainer.js
+++ b/client/src/containers/AdminIssueContainer.js
@@ -7,13 +7,20 @@ const mapStateToProps = state => ({
   issue: getIssue(state),
 });
 
-const mapDispatchToProps = dispatch => ({
-  closeIssue: (issue) => {
-    dispatch(closeIssue({ data: issue }));
-  },
-});
+// Following this example since we need id from state
+// https://github.com/reactjs/react-redux/issues/237#issuecomment-168817739
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+  const { dispatch } = dispatchProps;
+  return {
+    ...ownProps,
+    closeIssue: () => {
+      dispatch(closeIssue({ data: stateProps.issue }));
+    },
+  };
+};
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps,
+  null,
+  mergeProps,
 )(IssueAdmin);

--- a/client/src/containers/AdminIssueContainer.js
+++ b/client/src/containers/AdminIssueContainer.js
@@ -14,7 +14,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   return {
     ...ownProps,
     closeIssue: () => {
-      dispatch(closeIssue({ data: stateProps.issue }));
+      dispatch(closeIssue({ id: stateProps.issue.id }));
     },
   };
 };

--- a/client/src/containers/AdminIssueContainer.js
+++ b/client/src/containers/AdminIssueContainer.js
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux';
+import IssueAdmin from '../components/IssueAdmin';
+import { closeIssue } from '../actions/issues';
+import { getIssue } from '../selectors/issues';
+
+const mapStateToProps = state => ({
+  issue: getIssue(state),
+});
+
+const mapDispatchToProps = dispatch => ({
+  closeIssue: (issue) => {
+    dispatch(closeIssue({ data: issue }));
+  },
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(IssueAdmin);

--- a/client/src/selectors/issues.js
+++ b/client/src/selectors/issues.js
@@ -1,0 +1,5 @@
+export const getIssue = state => (
+  state.issues.length ? // Issues may not be added yet.
+  state.issues[state.issues.length - 1] :
+  undefined
+);

--- a/client/src/selectors/issues.js
+++ b/client/src/selectors/issues.js
@@ -1,5 +1,5 @@
-export const getIssue = state => (
-  state.issues.length ? // Issues may not be added yet.
-  state.issues[state.issues.length - 1] :
-  undefined
-);
+export const getIssue = state =>
+   // There might not be any issues yet.
+  state.issues.length && state.issues[state.issues.length - 1];
+
+export const getIssueText = state => getIssue(state) ? getIssue(state).text : '';

--- a/server/channels/issue.js
+++ b/server/channels/issue.js
@@ -8,11 +8,10 @@ const getUserById = require('../models/user').getUserById;
 
 const issue = (socket) => {
   socket.on('action', (data) => {
+    const payload = data.data;
     logger.debug('issue payload', { payload, action: data.type });
-    let payload;
     switch (data.type) {
       case 'server/ADMIN_CREATE_ISSUE':
-        payload = data.data;
         addQuestion(payload)
         .then((question) => {
           logger.debug('Added new question. Broadcasting ...', { question: question.description });
@@ -26,10 +25,9 @@ const issue = (socket) => {
           return null;
         });
         return null;
-        break
-      case 'close':
-        payload = data.data;
+      case 'server/CLOSE_ISSUE':
         if (!data.user) {
+          logger.debug('Someone tried to close an issue without passing user object.');
           emit(socket, 'issue', {}, {
             error: 'User id required to be able to close an ongoing issue.',
           });
@@ -58,8 +56,10 @@ const issue = (socket) => {
           return null;
         });
         return null;
-        break
-      }
+      default:
+        logger.warn('Hit default case for issue.');
+        break;
+    }
     return null;
   });
 };

--- a/server/channels/issue.js
+++ b/server/channels/issue.js
@@ -33,18 +33,18 @@ const issue = (socket) => {
           });
           return null;
         }
-        logger.info('Closing issue.', { issue: payload._id, user: data.user });
+        logger.info('Closing issue.', { issue: payload.id, user: data.user });
         getUserById(data.user).then((user) => {
           logger.debug('Fetched user profile', { user: user.name });
-          logger.debug('endq', { t: typeof endQuestion, endQuestion })
-          endQuestion(payload._id, user)
+          logger.debug('endq', { t: typeof endQuestion, endQuestion });
+          endQuestion(payload.id, user)
           .catch((err) => {
             logger.error('closing issue failed', { err });
             emit(socket, 'issue', {}, {
               error: 'Closing issue failed',
             });
           }).then((d) => {
-            logger.info('closed question', { question: payload._id, response: d._id });
+            logger.info('closed question', { question: payload.id, response: d._id });
             broadcast(socket, 'issue', payload, { action: 'close' });
           });
         }).catch((err) => {


### PR DESCRIPTION
Admin view now ships a button to close the active issue. This emits an event to the backend, ready to be handled.

This is done by adding wrapping the active Issue in the admin panel in a container with a button to close that issue.

Since the frontend has no login functionality yet, it can not ship the user id required by the backend function to close issue (because of permission level checking), so it does not actually _work_ at the moment. Whenever we have the user in the frontend, we can pass it along, and it should work.

This does ship with another example on how to connect the frontend and backend, so I think we should merge it anyways. Even though it doesn't work as it should yet, it doesn't break anything either.