### PR TITLE
Connect "Create Issue" to backend

### DIFF
--- a/client/src/actionCreators/adminButtons.js
+++ b/client/src/actionCreators/adminButtons.js
@@ -1,7 +1,7 @@
 import { ADMIN_CREATE_ISSUE, ADMIN_CLOSE_ISSUE, TOGGLE_REGISTRATION } from '../actionTypes/adminButtons';
 
 export const toggleRegistration = () => ({
-  type: ADMIN_CREATE_ISSUE,
+  type: TOGGLE_REGISTRATION,
 });
 
 export const adminCloseIssue = data => ({
@@ -9,7 +9,15 @@ export const adminCloseIssue = data => ({
   data,
 });
 
-export const createIssue = data => ({
-  type: TOGGLE_REGISTRATION,
-  data,
-});
+export const createIssue = (description, alternatives, voteDemand,
+  showOnlyWinner, secretElection) => ({
+    type: ADMIN_CREATE_ISSUE,
+    data: {
+      description,
+      options: alternatives,
+      voteDemand,
+      showOnlyWinner,
+      secret: secretElection,
+    },
+  }
+);

--- a/client/src/actionCreators/adminButtons.js
+++ b/client/src/actionCreators/adminButtons.js
@@ -10,14 +10,15 @@ export const adminCloseIssue = data => ({
 });
 
 export const createIssue = (description, alternatives, voteDemand,
-  showOnlyWinner, secretElection) => ({
+  showOnlyWinner, secretVoting, countBlankVotes) => ({
     type: ADMIN_CREATE_ISSUE,
     data: {
       description,
       options: alternatives,
       voteDemand,
       showOnlyWinner,
-      secret: secretElection,
+      secret: secretVoting,
+      countingBlankVotes: countBlankVotes,
     },
   }
 );

--- a/client/src/components/AdminPanel.js
+++ b/client/src/components/AdminPanel.js
@@ -68,7 +68,6 @@ class AdminPanel extends React.Component {
 }
 
 AdminPanel.propTypes = {
-  createIssue: PropTypes.func.isRequired,
   registrationEnabled: PropTypes.bool.isRequired,
   toggleRegistration: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,

--- a/client/src/components/IssueAdmin.js
+++ b/client/src/components/IssueAdmin.js
@@ -2,10 +2,10 @@ import React from 'react';
 import Button from './Button';
 import ActiveIssue from '../containers/ActiveIssue';
 
-const IssueAdmin = ({ closeIssue }) => (
+const IssueAdmin = ({ closeIssue, issue }) => (
   <div>
     <ActiveIssue />
-    <Button background onClick={closeIssue}>Avslutt sak</Button>
+    <Button background onClick={closeIssue} hidden={!issue}>Avslutt sak</Button>
   </div>
 );
 

--- a/client/src/components/IssueForm.js
+++ b/client/src/components/IssueForm.js
@@ -6,26 +6,70 @@ import SelectQuestionTypeContainer from '../containers/SelectQuestionTypeContain
 import AddIssueFormAlternative from '../containers/AddIssueFormAlternative';
 import IssueFormSettings from '../containers/IssueFormSettings';
 
-const IssueForm = () => (
-  <div className="IssueForm">
-    <label className="IssueForm-textarea">
-      <div className="IssueForm-label">Beskrivelse</div>
-      <textarea />
-      <p>Beskrivelse av saken</p>
-    </label>
-    <AddIssueFormAlternative />
-    <div className="IssueForm-label">Innstillinger</div>
-    <IssueFormSettings />
-    <label className="IssueForm-select">
-      <div className="IssueForm-label">Flertallstype</div>
-      <SelectResolutionTypeContainer />
-    </label>
-    <label className="IssueForm-select">
-      <div className="IssueForm-label">Spørsmålstype</div>
-      <SelectQuestionTypeContainer />
-    </label>
-    <Button background>Lagre sak</Button>
-  </div>
-);
+class IssueForm extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      issueDescription: '',
+    };
+
+    this.handleCreateIssue = this.handleCreateIssue.bind(this);
+    this.updateIssueDescription = this.updateIssueDescription.bind(this);
+  }
+
+  handleCreateIssue() {
+    const { createIssue } = this.props;
+    createIssue(this.state.issueDescription,
+      [{ text: 'alternative1' }, { text: 'alternative2' }, { text: 'alternative 3' }],
+      1, false, false, // @ToDo: Get these from state.
+    );
+  }
+
+  updateIssueDescription(e) {
+    this.setState({ issueDescription: e.target.value });
+  }
+
+  render() {
+    const issueReadyToCreate = this.state.issueDescription && this.state.issueDescription.length;
+    return (
+      <div className="IssueForm">
+        <label className="IssueForm-textarea">
+          <div className="IssueForm-label">Beskrivelse</div>
+          <textarea
+            onChange={this.updateIssueDescription}
+            placeholder="Skriv inn saken her."
+            value={this.state.issueDescription}
+          />
+          <p>Beskrivelse av saken</p>
+        </label>
+        <AddIssueFormAlternative />
+        <div className="IssueForm-label">Innstillinger</div>
+        <IssueFormSettings />
+        <label className="IssueForm-select">
+          <div className="IssueForm-label">Flertallstype</div>
+          <SelectResolutionTypeContainer />
+        </label>
+        <label className="IssueForm-select">
+          <div className="IssueForm-label">Spørsmålstype</div>
+          <SelectQuestionTypeContainer />
+        </label>
+        <Button
+          background
+          onClick={this.handleCreateIssue}
+          disabled={!issueReadyToCreate}
+        >Lagre sak</Button>
+      </div>
+    );
+  }
+}
+
+IssueForm.defaultProps = {
+  createIssue: undefined,
+};
+
+IssueForm.propTypes = {
+  createIssue: React.PropTypes.func,
+};
 
 export default IssueForm;

--- a/client/src/components/IssueForm.js
+++ b/client/src/components/IssueForm.js
@@ -63,7 +63,7 @@ class IssueForm extends React.Component {
   }
 
   render() {
-    const showActiveIssueWarning = this.props.issue;
+    const showActiveIssueWarning = this.props.issue && this.props.issue.text;
     const issueReadyToCreate = !showActiveIssueWarning && this.state.issueDescription && this.state.issueDescription.length;
     return (
       <div className="IssueForm">

--- a/client/src/components/IssueForm.js
+++ b/client/src/components/IssueForm.js
@@ -6,23 +6,35 @@ import SelectQuestionTypeContainer from '../containers/SelectQuestionTypeContain
 import AddIssueFormAlternative from '../containers/AddIssueFormAlternative';
 import IssueFormSettings from '../containers/IssueFormSettings';
 
+const YES_NO_ANSWERS = [
+  { text: 'Ja' },
+  { text: 'Nei' },
+];
+
 class IssueForm extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = {
       issueDescription: '',
+      alternatives: YES_NO_ANSWERS,
     };
 
+    this.handleAddAlternative = this.handleAddAlternative.bind(this);
     this.handleCreateIssue = this.handleCreateIssue.bind(this);
     this.updateIssueDescription = this.updateIssueDescription.bind(this);
   }
 
+  handleAddAlternative(alternativeText) {
+    const { alternatives } = this.state;
+    alternatives.push({ text: alternativeText });
+    this.setState({ alternatives });
+  }
+
   handleCreateIssue() {
     const { createIssue } = this.props;
-    createIssue(this.state.issueDescription,
-      [{ text: 'alternative1' }, { text: 'alternative2' }, { text: 'alternative 3' }],
-      1, false, false, // @ToDo: Get these from state.
+    createIssue(this.state.issueDescription, this.state.alternatives,
+      1, false, false, // @ToDo: Get from state.
     );
   }
 
@@ -43,7 +55,10 @@ class IssueForm extends React.Component {
           />
           <p>Beskrivelse av saken</p>
         </label>
-        <AddIssueFormAlternative />
+        <AddIssueFormAlternative
+          alternatives={this.state.alternatives}
+          handleAddAlternative={this.handleAddAlternative}
+        />
         <div className="IssueForm-label">Innstillinger</div>
         <IssueFormSettings />
         <label className="IssueForm-select">

--- a/client/src/components/IssueForm.js
+++ b/client/src/components/IssueForm.js
@@ -18,11 +18,17 @@ class IssueForm extends React.Component {
     this.state = {
       issueDescription: '',
       alternatives: YES_NO_ANSWERS,
+      secretVoting: false,
+      showOnlyWinner: false,
+      countBlankVotes: false,
     };
 
     this.handleAddAlternative = this.handleAddAlternative.bind(this);
     this.handleCreateIssue = this.handleCreateIssue.bind(this);
     this.updateIssueDescription = this.updateIssueDescription.bind(this);
+    this.handleUpdateCountBlankVotes = this.handleUpdateCountBlankVotes.bind(this);
+    this.handleUpdateSecretVoting = this.handleUpdateSecretVoting.bind(this);
+    this.handleUpdateShowOnlyWinner = this.handleUpdateShowOnlyWinner.bind(this);
   }
 
   handleAddAlternative(alternativeText) {
@@ -33,13 +39,27 @@ class IssueForm extends React.Component {
 
   handleCreateIssue() {
     const { createIssue } = this.props;
-    createIssue(this.state.issueDescription, this.state.alternatives,
-      1, false, false, // @ToDo: Get from state.
+    const { issueDescription, alternatives, countBlankVotes, secretVoting, showOnlyWinner } = this.state;
+    createIssue(issueDescription, alternatives,
+      1, // @ToDo: Get from state.
+      showOnlyWinner, secretVoting, countBlankVotes,
     );
   }
 
   updateIssueDescription(e) {
     this.setState({ issueDescription: e.target.value });
+  }
+
+  handleUpdateCountBlankVotes(countBlankVotes) {
+    this.setState({ countBlankVotes });
+  }
+
+  handleUpdateSecretVoting(secretVoting) {
+    this.setState({ secretVoting });
+  }
+
+  handleUpdateShowOnlyWinner(showOnlyWinner) {
+    this.setState({ showOnlyWinner });
   }
 
   render() {
@@ -60,7 +80,14 @@ class IssueForm extends React.Component {
           handleAddAlternative={this.handleAddAlternative}
         />
         <div className="IssueForm-label">Innstillinger</div>
-        <IssueFormSettings />
+        <IssueFormSettings
+          handleUpdateCountBlankVotes={this.handleUpdateCountBlankVotes}
+          handleUpdateSecretVoting={this.handleUpdateSecretVoting}
+          handleUpdateShowOnlyWinner={this.handleUpdateShowOnlyWinner}
+          countBlankVotes={this.state.countBlankVotes}
+          secretVoting={this.state.secretVoting}
+          showOnlyWinner={this.state.showOnlyWinner}
+        />
         <label className="IssueForm-select">
           <div className="IssueForm-label">Flertallstype</div>
           <SelectResolutionTypeContainer />

--- a/client/src/components/IssueForm.js
+++ b/client/src/components/IssueForm.js
@@ -63,9 +63,14 @@ class IssueForm extends React.Component {
   }
 
   render() {
-    const issueReadyToCreate = this.state.issueDescription && this.state.issueDescription.length;
+    const showActiveIssueWarning = this.props.issue;
+    const issueReadyToCreate = !showActiveIssueWarning && this.state.issueDescription && this.state.issueDescription.length;
     return (
       <div className="IssueForm">
+        <p
+          className="IssueForm--ActiveIssueWarning"
+          hidden={!showActiveIssueWarning}
+        >Det er allerede en aktiv sak!</p>
         <label className="IssueForm-textarea">
           <div className="IssueForm-label">Beskrivelse</div>
           <textarea

--- a/client/src/components/IssueFormAlternative.js
+++ b/client/src/components/IssueFormAlternative.js
@@ -21,9 +21,7 @@ class IssueFormAlternative extends React.Component {
   }
 
   handleAddAlternative() {
-    if (this.props.alternativeText) {
-      this.props.addAlternative(this.props.alternativeText);
-    }
+    this.props.handleAddAlternative(this.props.alternativeText);
   }
 
   handleKeyPress(event) {
@@ -69,8 +67,8 @@ class IssueFormAlternative extends React.Component {
     return display && (
       <div className="IssueFormAlternative">
         <ul>
-          {alternatives.map(alternative =>
-            <li key={alternative.id}>
+          {this.props.alternatives.map(alternative =>
+            <li key={alternative.text}>
               {alternative.text}
               <button
                 onClick={() => removeAlternative(alternative.id)}
@@ -110,10 +108,9 @@ IssueFormAlternative.propTypes = {
   alternativeUpdate: PropTypes.func.isRequired,
   updateAlternativeText: PropTypes.func.isRequired,
   display: PropTypes.bool.isRequired,
-  addAlternative: PropTypes.func.isRequired,
+  handleAddAlternative: PropTypes.func.isRequired,
   removeAlternative: PropTypes.func.isRequired,
   alternatives: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number.isRequired,
     text: PropTypes.string.isRequired,
   })).isRequired,
 };

--- a/client/src/components/IssueFormCheckboxes.js
+++ b/client/src/components/IssueFormCheckboxes.js
@@ -1,12 +1,15 @@
 import React, { PropTypes } from 'react';
 
-const IssueFormCheckboxes = ({ values, updateSetting }) => (
+const IssueFormCheckboxes = ({
+  countBlankVotes, secretVoting, showOnlyWinner,
+  handleUpdateCountBlankVotes, handleUpdateSecretVoting, handleUpdateShowOnlyWinner
+}) => (
   <div className="IssueFormCheckboxes">
     <label className="IssueForm-checkbox">
       <input
         type="checkbox"
-        onChange={e => updateSetting(0, e.target.checked)}
-        value={values[0]}
+        onChange={e => handleUpdateSecretVoting(e.target.checked)}
+        checked={secretVoting}
       />
       Hemmelig valg
     </label>
@@ -14,8 +17,8 @@ const IssueFormCheckboxes = ({ values, updateSetting }) => (
     <label className="IssueForm-checkbox">
       <input
         type="checkbox"
-        onChange={e => updateSetting(1, e.target.checked)}
-        value={values[1]}
+        onChange={e => handleUpdateShowOnlyWinner(e.target.checked)}
+        checked={showOnlyWinner}
       />
       Vis kun vinner
     </label>
@@ -23,8 +26,8 @@ const IssueFormCheckboxes = ({ values, updateSetting }) => (
     <label className="IssueForm-checkbox">
       <input
         type="checkbox"
-        onChange={e => updateSetting(2, e.target.checked)}
-        value={values[2]}
+        onChange={e => handleUpdateCountBlankVotes(e.target.checked)}
+        checked={countBlankVotes}
       />
       Tellende blanke stemmer
     </label>

--- a/client/src/containers/AddIssueFormAlternative.js
+++ b/client/src/containers/AddIssueFormAlternative.js
@@ -6,7 +6,6 @@ const mapStateToProps = state => ({
   alternativeText: state.issueFormAlternativeText,
   // Display the component if the question type is set to multiple choice.
   display: state.questionType === 1,
-  alternatives: state.createIssueAlternatives,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/client/src/containers/AdminPanelContainer.js
+++ b/client/src/containers/AdminPanelContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import AdminPanel from '../components/AdminPanel';
-import { createIssue, toggleRegistration } from '../actionCreators/adminButtons';
+import { toggleRegistration } from '../actionCreators/adminButtons';
 
 const mapStateToProps = ({ registrationEnabled }) => ({
   registrationEnabled,
@@ -10,18 +10,7 @@ const mapDispatchToProps = dispatch => ({
   toggleRegistration: () => {
     dispatch(toggleRegistration());
   },
-  createIssue: () => {
-    dispatch(createIssue({
-      description: 'My Q',
-      options: [
-        { text: 'Jakob' },
-        { text: 'Hallo' },
-        { text: 'LUL' },
-      ],
-      voteDemand: 0.5,
-    }));
-  }
-})
+});
 
 export default connect(
   mapStateToProps,

--- a/client/src/containers/IssueFormContainer.js
+++ b/client/src/containers/IssueFormContainer.js
@@ -9,9 +9,8 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  createIssue: (description, alternatives, voteDemand, showOnlyWinner, secretElection) => {
-    console.log('Adding issue', description);
-    dispatch(createIssue(description, alternatives, voteDemand, showOnlyWinner, secretElection));
+  createIssue: (description, alternatives, voteDemand, showOnlyWinner, secretElection, countBlankVotes) => {
+    dispatch(createIssue(description, alternatives, voteDemand, showOnlyWinner, secretElection, countBlankVotes));
   },
 });
 

--- a/client/src/containers/IssueFormContainer.js
+++ b/client/src/containers/IssueFormContainer.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux';
+import IssueForm from '../components/IssueForm';
+import { createIssue } from '../actionCreators/adminButtons';
+import { getIssue } from '../selectors/issues';
+
+const mapStateToProps = state => ({
+  issue: getIssue(state),
+  issueDescription: state.issueDescription ? state.issueDescription : '',
+});
+
+const mapDispatchToProps = dispatch => ({
+  createIssue: (description, alternatives, voteDemand, showOnlyWinner, secretElection) => {
+    console.log('Adding issue', description);
+    dispatch(createIssue(description, alternatives, voteDemand, showOnlyWinner, secretElection));
+  },
+});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(IssueForm);

--- a/client/src/containers/IssueFormSettings.js
+++ b/client/src/containers/IssueFormSettings.js
@@ -2,7 +2,8 @@ import { connect } from 'react-redux';
 import { updateSetting } from '../actionCreators/createIssueForm.js';
 import IssueFormCheckboxes from '../components/IssueFormCheckboxes';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state, ownProps) => ({
+  ...ownProps,
   values: state.issueSettings,
 });
 

--- a/client/src/css/IssueForm.css
+++ b/client/src/css/IssueForm.css
@@ -40,3 +40,10 @@ label.IssueForm-checkbox {
 .IssueForm label p {
   color: gray;
 }
+
+.IssueForm--ActiveIssueWarning {
+  background: #d15555;
+  border-radius: 5px;
+  padding: 10px 2px 10px 10px;
+  color: #FFEEEE;
+}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -8,7 +8,7 @@ import createSocketIoMiddleware from 'redux-socket.io';
 import AdminPanelContainer from './containers/AdminPanelContainer';
 import AppContainer from './containers/AppContainer';
 import AdminHome from './components/AdminHome';
-import IssueForm from './components/IssueForm';
+import IssueFormContainer from './containers/IssueFormContainer';
 import NotFound from './components/NotFound';
 import Users from './components/Users';
 import votingApp from './reducers';
@@ -31,7 +31,7 @@ ReactDOM.render(
       { /* We might want to split this up into two seperate apps */ }
       <Route path="admin" component={AdminPanelContainer}>
         <IndexRoute component={AdminHome} />
-        <Route path="question" component={IssueForm} />
+        <Route path="question" component={IssueFormContainer} />
         <Route path="users" component={Users} />
       </Route>
 

--- a/server/channels/issue.js
+++ b/server/channels/issue.js
@@ -2,8 +2,8 @@ const broadcast = require('../utils').broadcast;
 const emit = require('../utils').emit;
 const logger = require('../logging');
 
-const addQuestion = require('../models/issue').addQuestion;
-const endQuestion = require('../models/issue').endQuestion;
+const addIssue = require('../models/issue').addIssue;
+const endIssue = require('../models/issue').endIssue;
 const getUserByUsername = require('../models/user').getUserByUsername;
 
 module.exports = (socket) => {
@@ -12,7 +12,7 @@ module.exports = (socket) => {
     logger.debug('issue payload', { payload, action: data.type });
     switch (data.type) {
       case 'server/ADMIN_CREATE_ISSUE':
-        addQuestion(payload)
+        addIssue(payload)
         .then((question) => {
           logger.debug('Added new question. Broadcasting ...', { question: question.description });
           emit(socket, 'OPEN_ISSUE', question, { action: 'open' });
@@ -39,7 +39,7 @@ module.exports = (socket) => {
         logger.info('Closing issue.', { issue, adminUser });
         getUserByUsername(adminUser).then((user) => {
           logger.debug('Fetched user profile', { username: user.name, permissions: user.permissions });
-          endQuestion(issue, user)
+          endIssue(issue, user)
           .catch((err) => {
             logger.error('closing issue failed', { err });
             emit(socket, 'issue', {}, {
@@ -51,6 +51,7 @@ module.exports = (socket) => {
             emit(socket, 'CLOSE_ISSUE', updatedIssue);
           });
         }).catch((err) => {
+          console.log('getting user failed', err)
           logger.error('getting user failed', { err });
           emit(socket, 'issue', {}, {
             error: 'Something went wrong. Please try again. If the issue persists,' +

--- a/server/channels/issue.js
+++ b/server/channels/issue.js
@@ -15,6 +15,7 @@ module.exports = (socket) => {
         addQuestion(payload)
         .then((question) => {
           logger.debug('Added new question. Broadcasting ...', { question: question.description });
+          emit(socket, 'OPEN_ISSUE', question, { action: 'open' });
           broadcast(socket, 'OPEN_ISSUE', question, { action: 'open' });
           return null;
         }).catch((err) => {

--- a/server/models/issue.js
+++ b/server/models/issue.js
@@ -66,6 +66,7 @@ function updateQuestionCounter(question) {
 
 function addQuestion(issueData, closeCurrentIssue) {
   return new Promise((resolve, reject) => {
+    logger.debug('Creating issue', issueData);
     getActiveGenfors().then((genfors) => {
       if (!genfors) reject(new Error('No genfors active'));
 
@@ -87,6 +88,7 @@ function addQuestion(issueData, closeCurrentIssue) {
         // removed possible issues and proceeding to create a new one
         getQualifiedUsers(genfors, issueData.secret).then((users) => {
           const issue = Object.assign(issueData, {
+            genfors,
             qualifiedVoters: users.length,
             currentVotes: 0,
           });

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -80,10 +80,14 @@ function addUser(name, onlinewebId, passwordHash, securityLevel) {
 
       Promise.all([user.save(), anonymousUser.save()])
         .then((p) => {
+          logger.debug('Created user', user.name);
           resolve({ user: p[0], anonymousUser: p[1] });
-        }).catch(reject);
+        }).catch((err) => {
+          logger.error('Failed to create user', user.name);
+          reject(err);
+        });
       return null;
-    });
+    }).catch(reject);
   });
 }
 


### PR DESCRIPTION
This makes it possible to create issues in the frontend and persist it in the backend.

Notes:
* The issue creation should be refactored into using pure react state, rather than redux, since it's not to be used outside of this page. Therefore, some of the functionality (options and vote demand) does not impact it at the moment. 

What works nicely, though, is the text area (issue description) and either Y/N questions or multiple choice answers (it's not possible to remove custom answers at the moment either, because of the pending refactor).