### PR TITLE
Fix state props not being passed to IssueAdmin from prop merger

### DIFF
--- a/client/src/containers/AdminIssueContainer.js
+++ b/client/src/containers/AdminIssueContainer.js
@@ -11,8 +11,10 @@ const mapStateToProps = state => ({
 // https://github.com/reactjs/react-redux/issues/237#issuecomment-168817739
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const { dispatch } = dispatchProps;
+
   return {
     ...ownProps,
+    ...stateProps,
     closeIssue: () => {
       dispatch(adminCloseIssue({ issue: stateProps.issue.id, user: 'admin' }));
     },

--- a/client/src/selectors/issues.js
+++ b/client/src/selectors/issues.js
@@ -3,8 +3,7 @@ export const getIssue = (state) => {
     return {};
   }
   // Gets the current active issue after iterating over all issues and finding the one with "active == true"
-  return state.issues[Object.keys(state.issues)
-    .filter(issueId => state.issues[issueId].active)[0]];
+  return state.issues[Object.keys(state.issues).filter(id => state.issues[id].active)[0]];
 };
 
 const getKeyForIssueObjIfExists = (state, key, defaultValue = undefined) => {


### PR DESCRIPTION
Fixes the issue closing button being invisible, due to state props never being passed to IssueAdmin from a custom mergeProps function.