### PR TITLE
Vote status changes

### DIFF
--- a/client/src/components/VoteCounter.js
+++ b/client/src/components/VoteCounter.js
@@ -4,7 +4,7 @@ import '../css/VoteCounter.css';
 const VoteCounter = ({ count, total, label }) => (
   <div className="VoteCounter">
     <div className="VoteCounter-label">
-      { label } ({ count } / { total })
+      { label } <span className="VoteCounter-count">({ count } / { total })</span>
     </div>
     <div className="VoteCounter-bar">
       <div className="VoteCounter-bar-progress" style={{ width: `${(count / total) * 100}%` }} />

--- a/client/src/components/VoteStatus.js
+++ b/client/src/components/VoteStatus.js
@@ -15,7 +15,7 @@ const VoteStatus = ({ voteCount, userCount, alternatives, votePercentages }) => 
         label={`Alternativ ${i + 1}`}
         count={votePercentages[alternative.id]}
         key={alternative.id}
-        total={userCount}
+        total={voteCount}
       />,
     )}
 

--- a/client/src/components/VoteStatus.js
+++ b/client/src/components/VoteStatus.js
@@ -12,7 +12,7 @@ const VoteStatus = ({ voteCount, userCount, alternatives, votePercentages }) => 
 
     {alternatives && alternatives.map((alternative, i) =>
       <VoteCounter
-        label={`Alternativ ${i + 1}`}
+        label={alternative.text}
         count={votePercentages[alternative.id]}
         key={alternative.id}
         total={voteCount}

--- a/client/src/css/VoteCounter.css
+++ b/client/src/css/VoteCounter.css
@@ -15,3 +15,15 @@
   background: #6b71a5;
   height: 100%;
 }
+
+.VoteCounter-label {
+  display: flex;
+}
+
+.VoteCounter-count {
+  margin-left: auto;
+  min-width: 5rem;
+  flex-basis: auto;
+  text-align: right;
+  align-self: flex-end;
+}


### PR DESCRIPTION
- Use vote count to calculate vote percentages instead of user count
- Use alternative.text as label for votes
- Align votes (x/y) to the right side

![image](https://cloud.githubusercontent.com/assets/1637715/24711561/9ec35692-1a20-11e7-9561-be1871c74fbd.png)
