### PR TITLE
Only count users who are permitted to vote

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -34,9 +34,13 @@ const AnonymousUser = mongoose.model('AnonymousUser', AnonymousUserSchema);
 
 function getQualifiedUsers(genfors, secret) {
   if (secret) {
-    return AnonymousUser.find({ genfors, permissions: { $gt: permissionLevel.CAN_VOTE } });
+    return AnonymousUser.find({
+      genfors,
+      canVote: true,
+      permissions: { $gt: permissionLevel.CAN_VOTE },
+    });
   }
-  return User.find({ genfors, permissions: { $gt: permissionLevel.CAN_VOTE } });
+  return User.find({ genfors, canVote: true, permissions: { $gt: permissionLevel.CAN_VOTE } });
 }
 
 function getUserById(userId, anonymous) {


### PR DESCRIPTION
When creating a new issue, this function is ran. This is supposed to count the users who are allowed to vote when the issue is opened. Currently, it counts everyone who has the required permission level to vote, and does not take into consideration if their `canVote`-flag is `false` (this is the flag that admins toggle to give/revoke voting rights in the admin panel).

This change adds the `canVote` flag to the lookup query, which makes it only count the users who actually are allowed to vote at the time of issue creation.