### PR TITLE
Disable voting input after having voted

### DIFF
--- a/client/src/components/Alternative.js
+++ b/client/src/components/Alternative.js
@@ -11,6 +11,7 @@ const Alternative = ({ disabled, id, text, selected, onClick }) => {
     <div className={alternativeClass} key={id}>
       <label>
         <input
+          disabled={disabled}
           type="radio"
           name="vote"
           value={id}

--- a/client/src/components/Alternatives.js
+++ b/client/src/components/Alternatives.js
@@ -6,7 +6,7 @@ const Alternatives = ({ disabled, alternatives, handleChange, selectedVote }) =>
   <div className={css.lternatives}>
     {alternatives.map(alternative => (
       <Alternative
-        disabled={disabled}
+        disabled={disabled && alternative.id !== selectedVote}
         key={alternative.id} {...alternative}
         onClick={handleChange} selected={alternative.id === selectedVote}
       />

--- a/client/src/components/App/VotingMenu.js
+++ b/client/src/components/App/VotingMenu.js
@@ -37,13 +37,14 @@ class VotingMenu extends React.Component {
   render() {
     const isLoggedIn = this.props.loggedIn;
     const hasSelectedVote = this.state.selectedVote !== undefined;
-    const hasVoted = this.props.votedState.alternative;
+    const hasVoted = !!this.props.votedState.alternative;
     const buttonDisabled = !isLoggedIn || !hasSelectedVote || hasVoted;
 
     return (
       <div>
         <Alternatives
           alternatives={this.props.alternatives}
+          disabled={hasVoted}
           handleChange={(...a) => this.handleChange(...a)}
           selectedVote={this.state.selectedVote}
         />


### PR DESCRIPTION
Previously, it was possible to select another alternative after having voted. It was not possible to change the vote to that alternative, so the "Vote" button was disabled. There is no reason for the user to be able to click on another alternative after having voted, so this change removes that unneeded functionality.

## Before

### After having voted, the alternative voted for would show.
![screenshot 2017-04-18 00 55 30](https://cloud.githubusercontent.com/assets/5422571/25107789/d3267abc-23d1-11e7-89a9-d225e9d717e9.png)

### It was possible to hide the alternative voted for
![screenshot 2017-04-18 00 55 25](https://cloud.githubusercontent.com/assets/5422571/25107787/d320bbb8-23d1-11e7-943e-00d1401e8aa9.png)

### It was possible to click on another alternative after having voted
![screenshot 2017-04-18 00 55 38](https://cloud.githubusercontent.com/assets/5422571/25107788/d3250a06-23d1-11e7-9983-308370f9c2f5.png)

## After 

### After having voted, the alternative voted for will show.  
It is not possible to click any other alternative.  
![screenshot 2017-04-18 00 53 50](https://cloud.githubusercontent.com/assets/5422571/25107785/d31ed906-23d1-11e7-84d6-88de9d06c9dd.png)

### It is possible to hide the alternative voted for.  
It is not possible to click any other alternative.  
![screenshot 2017-04-18 00 53 43](https://cloud.githubusercontent.com/assets/5422571/25107786/d31f039a-23d1-11e7-90eb-9c99406ffb98.png)