### PR TITLE
Fix #63. Empty input after submitting

### DIFF
--- a/client/src/components/Admin/IssueForm/Alternative.js
+++ b/client/src/components/Admin/IssueForm/Alternative.js
@@ -16,7 +16,10 @@ class Alternative extends React.Component {
   }
 
   handleAddAlternative() {
-    this.props.handleAddAlternative(this.state.alternativeText);
+    if (this.state.alternativeText.length > 0) {
+      this.props.handleAddAlternative(this.state.alternativeText);
+      this.setState({ alternativeText: '' });
+    }
   }
 
   handleAlternativeUpdate(event) {


### PR DESCRIPTION
Make sure it's not possible to submit empty alternatives.