### PR TITLE
Make it possible to hide close symbol of dialog

### DIFF
--- a/client/src/components/Dialog.js
+++ b/client/src/components/Dialog.js
@@ -7,6 +7,11 @@ const Dialog = ({ visible, title, onClose, children, hideCloseSymbol }) => {
   const dialogClass = classNames(css.component, {
     [css.visible]: visible,
   });
+  // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+  const corner = !hideCloseSymbol && <div
+    onClick={onClose}
+    className={css.close}
+  />;
   return (
     <div className={dialogClass}>
       <div // eslint-disable-line jsx-a11y/no-static-element-interactions
@@ -16,13 +21,7 @@ const Dialog = ({ visible, title, onClose, children, hideCloseSymbol }) => {
       <Card
         classes={css.dialog}
         title={title}
-        corner={
-          <div // eslint-disable-line jsx-a11y/no-static-element-interactions
-            onClick={onClose}
-            className={css.close}
-            hidden={hideCloseSymbol}
-          />
-        }
+        corner={corner}
       >
         {children}
       </Card>

--- a/client/src/components/Dialog.js
+++ b/client/src/components/Dialog.js
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import Card from './Card';
 import css from './Dialog.css';
 
-const Dialog = ({ visible, title, onClose, children }) => {
+const Dialog = ({ visible, title, onClose, children, hideCloseSymbol }) => {
   const dialogClass = classNames(css.component, {
     [css.visible]: visible,
   });
@@ -20,6 +20,7 @@ const Dialog = ({ visible, title, onClose, children }) => {
           <div // eslint-disable-line jsx-a11y/no-static-element-interactions
             onClick={onClose}
             className={css.close}
+            hidden={hideCloseSymbol}
           />
         }
       >
@@ -30,10 +31,12 @@ const Dialog = ({ visible, title, onClose, children }) => {
 };
 
 Dialog.defaultProps = {
+  hideCloseSymbol: false,
   visible: false,
 };
 
 Dialog.propTypes = {
+  hideCloseSymbol: PropTypes.bool,
   visible: PropTypes.bool,
   title: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([


### PR DESCRIPTION
This can be useful if the dialog is used for something where it should not be possible to close the dialog, e.g. for forcing the user to sign up or sign in, or when requiring the user to reload the page.