### PR TITLE
Hides close symbol for new version dialog

### DIFF
--- a/client/src/components/NewVersionAvailable.js
+++ b/client/src/components/NewVersionAvailable.js
@@ -5,6 +5,7 @@ import css from './NewVersionAvailable.css';
 const NewVersionAvailable = ({ newVersionAvailable }) => (
   <Dialog
     onClose={() => { window.location.href = '.'; }}
+    hideCloseSymbol
     title="En ny versjon av applikasjonen er tilgjengelig"
     visible={newVersionAvailable}
   >


### PR DESCRIPTION
Depends on #81 being approved and merged.

This will remove the close button from the dialog, since the user should not be able to close the dialog, but rather reload the page.

This will make the dialog look like this

![screenshot 2017-04-21 01 34 18](https://cloud.githubusercontent.com/assets/5422571/25257230/d44a8368-2636-11e7-85f6-0797263515bd.png)

rather than this

![screenshot 2017-04-21 02 10 58](https://cloud.githubusercontent.com/assets/5422571/25257357/ccabe1be-2637-11e7-9fa3-6f22ef8fac4d.png)