### PR TITLE
Show error message rather than instantly redirecting user

### DIFF
--- a/client/src/components/App/Setup.css
+++ b/client/src/components/App/Setup.css
@@ -30,3 +30,7 @@
 .warning {
   color: #9c0707;
 }
+
+.dialog {
+  padding-bottom: inherit;
+}

--- a/client/src/components/App/Setup.js
+++ b/client/src/components/App/Setup.js
@@ -79,9 +79,9 @@ class Setup extends Component {
           hideCloseSymbol
           onClose={() => { window.location.href = '/'; }}
           title={'En feil har oppstått'}
+          subtitle={'Du er allerede registrert'}
           visible={registered}
         >
-          <h3>Du er allerede registrert</h3>
           <p className={css.dialog}>
             Du vil nå bli videresent til forsiden.
             Dersom det ikke skjer automatisk, <a href="/">trykk her</a>.

--- a/client/src/components/App/Setup.js
+++ b/client/src/components/App/Setup.js
@@ -1,10 +1,10 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { Redirect } from 'react-router-dom';
 import SHA256 from 'crypto-js/sha256';
 import Cookies from 'js-cookie';
 import { register } from '../../actionCreators/auth';
 import Button from '../Button';
+import Dialog from '../Dialog';
 import Card from '../Card';
 import css from './Setup.css';
 
@@ -71,10 +71,22 @@ class Setup extends Component {
     const errorMessage = this.validate();
     // Redirect to home if already registered
     if (registered) {
-      return <Redirect to="/" />;
+      setTimeout(() => { window.location.href = '/'; }, 5000);
     }
     return (
       <Card classes={css.setup} title="Registrering for generalforsamling">
+        <Dialog
+          hideCloseSymbol
+          onClose={() => { window.location.href = '/'; }}
+          title={'En feil har oppstått'}
+          visible={registered}
+        >
+          <h3>Du er allerede registrert</h3>
+          <p className={css.dialog}>
+            Du vil nå bli videresent til forsiden.
+            Dersom det ikke skjer automatisk, <a href="/">trykk her</a>.
+          </p>
+        </Dialog>
         <form onSubmit={e => this.submit(e)}>
           <label>
             <div className={css.text}>Pin kode</div>


### PR DESCRIPTION
I think this is better behaviour than instantly redirecting a user, especially if we don't have any way of telling the user about this on the front page (like toasts or something).

Looks like this 
![screenshot 2017-04-23 23 59 23](https://cloud.githubusercontent.com/assets/5422571/25317848/77c23b66-2881-11e7-8d01-04474a1fc96c.png)
