### PR TITLE
Set auth proptype defaults rather than isRequired

### DIFF
--- a/client/src/components/App/Home.js
+++ b/client/src/components/App/Home.js
@@ -22,9 +22,13 @@ const Home = ({ issueExists, registered }) => (
   </div>
 );
 
+Home.defaultProps = {
+  registered: undefined,
+};
+
 Home.propTypes = {
   issueExists: PropTypes.bool.isRequired,
-  registered: PropTypes.bool.isRequired,
+  registered: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({

--- a/client/src/components/App/VotingMenu.js
+++ b/client/src/components/App/VotingMenu.js
@@ -81,6 +81,7 @@ VotingMenu.defaultProps = {
   voterKey: undefined,
   alternatives: [],
   issueId: '',
+  loggedIn: undefined,
   selectedAlternative: null,
 };
 
@@ -89,7 +90,7 @@ VotingMenu.propTypes = {
   handleVote: React.PropTypes.func.isRequired,
   issueId: React.PropTypes.string,
   issueIsActive: React.PropTypes.bool.isRequired,
-  loggedIn: React.PropTypes.bool.isRequired,
+  loggedIn: React.PropTypes.bool,
   selectedAlternative: React.PropTypes.string,
   voterKey: React.PropTypes.number,
 };


### PR DESCRIPTION
The auth socket event might not have been received at first render, so the proptype validation can fail.