### PR TITLE
Feature/141 edit issue

### DIFF
--- a/client/src/components/Admin/Issue.js
+++ b/client/src/components/Admin/Issue.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
 import Button from '../Button';
 import Card from '../Card';
 import Dialog from '../Dialog';
@@ -13,6 +14,7 @@ class Issue extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      redirectToEditIssue: false,
       showCloseIssueDialog: false,
     };
   }
@@ -33,6 +35,7 @@ class Issue extends React.Component {
     const { showCloseIssueDialog } = this.state;
     return (
       <Card classes={css.issue}>
+        {this.state.redirectToEditIssue && <Redirect to="/admin/question" />}
         <Dialog
           title="Bekreft sletting av sak"
           subtitle={`Bekreft sletting av "${issueText}"`}
@@ -50,7 +53,11 @@ class Issue extends React.Component {
             <p className={css.title}>Aktiv sak</p>
           </div>
           {issueIsActive && <div className={css.actions}>
-            <ButtonIconText text="Rediger" iconClass={css.edit} />
+            <ButtonIconText
+              text="Rediger"
+              iconClass={css.edit}
+              onClick={() => { this.setState({ redirectToEditIssue: true }); }}
+            />
             <ButtonIconText text="Resett" iconClass={css.reset} />
             <ButtonIconText text="Avslutt" iconClass={css.end} onClick={closeIssue} />
             <ButtonIconText

--- a/client/src/components/Admin/IssueForm/index.js
+++ b/client/src/components/Admin/IssueForm/index.js
@@ -111,7 +111,10 @@ class IssueForm extends React.Component {
       issueAlternatives = YES_NO_ANSWERS.slice();
     }
 
-    DEFAULT_ALTERNATIVES.forEach(alternative => issueAlternatives.push(alternative));
+    if (!this.state.editingIssue) {
+      // Only add default options if not editing issue. Otherwise they'll already be added.
+      DEFAULT_ALTERNATIVES.forEach(alternative => issueAlternatives.push(alternative));
+    }
 
     this.props.createIssue(
       this.state.issueDescription,

--- a/client/src/components/Admin/IssueForm/index.js
+++ b/client/src/components/Admin/IssueForm/index.js
@@ -33,20 +33,32 @@ const YES_NO_ANSWERS = [
 
 let alternativeId = 0;
 
+const blankIssue = {
+  issueDescription: '',
+  alternatives: {},
+  secretVoting: false,
+  showOnlyWinner: false,
+  countBlankVotes: false,
+  voteDemand: RESOLUTION_TYPES.regular.key,
+  questionType: MULTIPLE_CHOICE,
+};
+
 class IssueForm extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      issueDescription: '',
-      alternatives: {},
-      secretVoting: false,
-      showOnlyWinner: false,
-      countBlankVotes: false,
-      voteDemand: RESOLUTION_TYPES.regular.key,
-      questionType: MULTIPLE_CHOICE,
+    const issue = props.issue || {};
+
+    this.state = Object.assign(blankIssue, {
+      issueDescription: issue.text || '',
+      alternatives: issue.alternatives || {},
+      secretVoting: issue.secret || false,
+      showOnlyWinner: issue.showOnlyWinner || false,
+      countBlankVotes: issue.countingBlankVotes || false,
+      voteDemand: issue.voteDemand || RESOLUTION_TYPES.regular.key,
+      questionType: MULTIPLE_CHOICE, // @ToDo: This is not stored in state.
       redirectToAdminHome: false,
-    };
+    });
   }
 
   handleAddAlternative(text) {
@@ -197,15 +209,27 @@ class IssueForm extends React.Component {
 
 IssueForm.defaultProps = {
   createIssue: undefined,
+  issue: {},
 };
 
 IssueForm.propTypes = {
   createIssue: React.PropTypes.func,
+  issue: React.PropTypes.objectOf(React.PropTypes.shape({
+    active: React.PropTypes.bool.isRequired,
+    alternatives: React.PropTypes.arrayOf(
+      React.PropTypes.objectOf({
+        text: React.PropTypes.string.isRequired,
+      })),
+    secret: React.PropTypes.bool.isRequired,
+    showOnlyWinner: React.PropTypes.bool.isRequired,
+    voteDemand: React.PropTypes.string.isRequired,
+  })),
   activeIssue: React.PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
   activeIssue: activeIssueExists(state),
+  issue: getIssue(state),
   issueDescription: state.issueDescription ? state.issueDescription : '',
 });
 

--- a/client/src/components/Admin/IssueForm/index.js
+++ b/client/src/components/Admin/IssueForm/index.js
@@ -43,22 +43,29 @@ const blankIssue = {
   questionType: MULTIPLE_CHOICE,
 };
 
+function getIssueContents(issue) {
+  return Object.assign(blankIssue, {
+    issueDescription: issue.text || '',
+    alternatives: issue.alternatives || {},
+    secretVoting: issue.secret || false,
+    showOnlyWinner: issue.showOnlyWinner || false,
+    countBlankVotes: issue.countingBlankVotes || false,
+    voteDemand: issue.voteDemand || RESOLUTION_TYPES.regular.key,
+    questionType: MULTIPLE_CHOICE, // @ToDo: This is not stored in state.
+  });
+}
+
 class IssueForm extends React.Component {
   constructor(props) {
     super(props);
 
     const issue = props.issue || {};
 
-    this.state = Object.assign(blankIssue, {
-      issueDescription: issue.text || '',
-      alternatives: issue.alternatives || {},
-      secretVoting: issue.secret || false,
-      showOnlyWinner: issue.showOnlyWinner || false,
-      countBlankVotes: issue.countingBlankVotes || false,
-      voteDemand: issue.voteDemand || RESOLUTION_TYPES.regular.key,
-      questionType: MULTIPLE_CHOICE, // @ToDo: This is not stored in state.
+    const issueContents = getIssueContents(issue);
+
+    this.state = Object.assign(issueContents, {
       redirectToAdminHome: false,
-      editingIssue: issue.text && issue.text.length > 0,
+      editingIssue: props.activeIssue,
     });
   }
 
@@ -149,10 +156,9 @@ class IssueForm extends React.Component {
   }
 
   toggleUpdateExistingIssue() {
-    this.setState({
-      issueDescription: this.props.issue.text,
+    this.setState(Object.assign(getIssueContents(this.props.issue), {
       editingIssue: true,
-    });
+    }));
   }
 
   toggleCreateNewIssue() {


### PR DESCRIPTION
Resolves #141.

Does all its magic client side, by firstly deleting the current active issue and then creating a new issue.

I created [`feature/edit-issue-server-side`](https://github.com/dotkom/super-duper-fiesta/tree/feature/edit-issue-server-side) as a start for doing this server side, as this could create a race condition if the issue is created before the currently active one is closed. The back end won't accept this though, as it doesn't allow to create a new issue unless the currently active one is closed first, but if the back end receives a request to create a new issue before the request to close the current one, this might happen. Should not be hard to do the whole shebang in the back end though, the same way we do it in the front end now.