### PR TITLE
Rename getQuestions to getConcludedIssues and only return concluded issues

### DIFF
--- a/server/channels/__tests__/connection.js
+++ b/server/channels/__tests__/connection.js
@@ -12,7 +12,7 @@ const connection = require('../connection');
 const { getActiveGenfors } = require('../../models/meeting');
 const { getAnonymousUser } = require('../../models/user');
 const { getVotes, haveIVoted } = require('../../models/vote');
-const { getActiveQuestion, getQuestions } = require('../../models/issue');
+const { getActiveQuestion, getConcludedIssues } = require('../../models/issue');
 const { generateSocket, generateGenfors, generateAnonymousUser, generateIssue, generateVote } = require('../../utils/generateTestData');
 
 
@@ -26,7 +26,7 @@ describe('connection', () => {
       },
     ));
     getActiveQuestion.mockImplementation(async () => generateIssue());
-    getQuestions.mockImplementation(async meeting => [
+    getConcludedIssues.mockImplementation(async meeting => [
       generateIssue({ meeting: meeting.id, _id: '2' }),
       generateIssue({ meeting: meeting.id, _id: '2' }),
       generateIssue({ meeting: meeting.id, _id: '2' }),
@@ -130,7 +130,7 @@ describe('connection', () => {
   });
 
   it('emits correct actions when retrieving questions fails', async () => {
-    getQuestions.mockImplementation(async () => { throw new Error('Failed'); });
+    getConcludedIssues.mockImplementation(async () => { throw new Error('Failed'); });
     await connection(generateSocket());
 
     expect(emit.mock.calls).toMatchSnapshot();

--- a/server/channels/connection.js
+++ b/server/channels/connection.js
@@ -3,7 +3,7 @@ const logger = require('../logging');
 
 const getActiveGenfors = require('../models/meeting').getActiveGenfors;
 const getActiveQuestion = require('../models/issue').getActiveQuestion;
-const getQuestions = require('../models/issue').getQuestions;
+const { getConcludedIssues } = require('../models/issue');
 const getVotes = require('../models/vote').getVotes;
 const { generatePublicVote } = require('../managers/vote');
 const haveIVoted = require('../models/vote').haveIVoted;
@@ -113,7 +113,7 @@ const emitActiveQuestion = async (socket, meeting) => {
 
 const emitIssueBacklog = async (socket, meeting) => {
   try {
-    const issues = await getQuestions(meeting);
+    const issues = await getConcludedIssues(meeting);
     await Promise.all(issues.map(async (issue) => {
       // Get votes for backlogged issues
       emit(socket, CLOSE_ISSUE, await getPublicIssueWithVotes(issue));

--- a/server/models/issue.js
+++ b/server/models/issue.js
@@ -25,9 +25,10 @@ function addIssue(issue) {
   return new Question(issue).save();
 }
 
-function getQuestions(genfors) {
-  return Question.find({ genfors, deleted: false }).exec();
+function getConcludedIssues(genfors) {
+  return Question.find({ genfors, deleted: false, active: false }).exec();
 }
+
 const getIssueById = id => (
   Question.findOne({ _id: id })
 );
@@ -51,7 +52,7 @@ module.exports = {
   getActiveQuestion,
   getClosedQuestions,
   getIssueById,
-  getQuestions,
+  getConcludedIssues,
   endIssue,
   // updateQuestionCounter,
   deleteIssue,


### PR DESCRIPTION
This way it avoids overwriting active issue state in funky ways