### PR TITLE
Rewrote error emitting

### DIFF
--- a/client/src/actionCreators/error.js
+++ b/client/src/actionCreators/error.js
@@ -1,6 +1,9 @@
 import { ERROR_DISMISS } from '../../../common/actionTypes/error';
 
 // eslint-disable-next-line import/prefer-default-export
-export const dismissError = () => ({
+export const dismissError = id => ({
   type: ERROR_DISMISS,
+  data: {
+    id,
+  },
 });

--- a/client/src/components/Error.css
+++ b/client/src/components/Error.css
@@ -1,4 +1,5 @@
 .error {
+  margin-bottom: 2rem;
   display: flex;
   background: #ca3939;
   padding: 0.5rem 1rem;

--- a/client/src/components/Error.js
+++ b/client/src/components/Error.js
@@ -3,29 +3,27 @@ import { connect } from 'react-redux';
 import { dismissError } from '../actionCreators/error';
 import css from './Error.css';
 
-const Error = ({ errors, dismiss }) => {
-  return (
-    <div>
-      { errors.map(error => (
-        <div className={css.error}>
-          <span className={css.message}>{error.message}</span>
-          <button className={css.corner} onClick={() => dismiss(error.id)}>
-            <div className={css.close} />
-          </button>
-        </div>
-      ))}
-    </div>
-  );
-};
+const Error = ({ errors, dismiss }) => (
+  <div>
+    { errors.map(error => (
+      <div key={error.id} className={css.error}>
+        <span className={css.message}>{error.message}</span>
+        <button className={css.corner} onClick={() => dismiss(error.id)}>
+          <div className={css.close} />
+        </button>
+      </div>
+    ))}
+  </div>
+);
 
 Error.defaultProps = {
   errors: [],
 };
 
 Error.propTypes = {
-  errors: PropTypes.objectOf(PropTypes.shape({
+  errors: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.number,
-    message: PropTypes.message,
+    message: PropTypes.string,
   })),
   dismiss: PropTypes.func.isRequired,
 };

--- a/client/src/components/Error.js
+++ b/client/src/components/Error.js
@@ -3,38 +3,39 @@ import { connect } from 'react-redux';
 import { dismissError } from '../actionCreators/error';
 import css from './Error.css';
 
-const Error = ({ dismiss, message }) => {
-  if (!message) {
-    return null;
-  }
+const Error = ({ errors, dismiss }) => {
   return (
-    <div className={css.error}>
-      <span className={css.message}>{message}</span>
-      { dismiss &&
-        <button className={css.corner} onClick={dismiss}>
-          <div className={css.close} />
-        </button>
-      }
+    <div>
+      { errors.map(error => (
+        <div className={css.error}>
+          <span className={css.message}>{error.message}</span>
+          <button className={css.corner} onClick={() => dismiss(error.id)}>
+            <div className={css.close} />
+          </button>
+        </div>
+      ))}
     </div>
   );
 };
 
 Error.defaultProps = {
-  message: null,
-  dismiss: null,
+  errors: [],
 };
 
 Error.propTypes = {
-  message: PropTypes.string,
-  dismiss: PropTypes.func,
+  errors: PropTypes.objectOf(PropTypes.shape({
+    id: PropTypes.number,
+    message: PropTypes.message,
+  })),
+  dismiss: PropTypes.func.isRequired,
 };
 
 export default Error;
 
 const mapStateToProps = ({ error }) => ({
-  message: error,
+  errors: Object.keys(error).map(key => error[key]),
 });
-const mapDispatchToProps = dispatch => ({
-  dismiss: () => dispatch(dismissError()),
-});
+const mapDispatchToProps = {
+  dismiss: dismissError,
+};
 export const ErrorContainer = connect(mapStateToProps, mapDispatchToProps)(Error);

--- a/client/src/reducers/error.js
+++ b/client/src/reducers/error.js
@@ -1,15 +1,27 @@
-import { AUTH_ERROR, ERROR_DISMISS } from '../../../common/actionTypes/error';
+import { ERROR, ERROR_DISMISS } from '../../../common/actionTypes/error';
 
-const errorReducer = (state = null, action) => {
+const errorsReducer = (state = {}, action) => {
   const { type, data } = action;
 
   switch (type) {
-    case ERROR_DISMISS: return null;
-    case AUTH_ERROR: {
-      return data.error;
+    case ERROR_DISMISS: {
+      const { id } = data;
+      return Object.keys(state).reduce((acc, key) => {
+        const newState = acc;
+        if (key !== id.toString()) {
+          newState[key] = state[key];
+        }
+        return newState;
+      }, {});
+    }
+    case ERROR: {
+      return {
+        ...state,
+        [data.id]: data,
+      };
     }
     default: return state;
   }
 };
 
-export default errorReducer;
+export default errorsReducer;

--- a/common/actionTypes/error.js
+++ b/common/actionTypes/error.js
@@ -1,4 +1,4 @@
 module.exports = {
-  AUTH_ERROR: 'AUTH_ERROR',
+  ERROR: 'ERROR',
   ERROR_DISMISS: 'ERROR_DISMISS',
 };

--- a/server/channels/__tests__/__snapshots__/auth.js.snap
+++ b/server/channels/__tests__/__snapshots__/auth.js.snap
@@ -6,7 +6,8 @@ Array [
     "action",
     Object {
       "data": Object {
-        "error": "Noe gikk galt under registreringen. Prøv igjen",
+        "id": 0,
+        "message": "Noe gikk galt under registreringen. Prøv igjen",
       },
       "type": "ERROR",
     },
@@ -20,7 +21,8 @@ Array [
     "action",
     Object {
       "data": Object {
-        "error": "Validering av personlig kode feilet",
+        "id": 0,
+        "message": "Validering av personlig kode feilet",
       },
       "type": "ERROR",
     },
@@ -34,7 +36,8 @@ Array [
     "action",
     Object {
       "data": Object {
-        "error": "Feil pinkode",
+        "id": 0,
+        "message": "Feil pinkode",
       },
       "type": "ERROR",
     },
@@ -48,7 +51,8 @@ Array [
     "action",
     Object {
       "data": Object {
-        "error": "Registreringen er ikke åpen.",
+        "id": 0,
+        "message": "Registreringen er ikke åpen.",
       },
       "type": "ERROR",
     },
@@ -62,7 +66,8 @@ Array [
     "action",
     Object {
       "data": Object {
-        "error": "Feil personlig kode",
+        "id": 0,
+        "message": "Feil personlig kode",
       },
       "type": "ERROR",
     },

--- a/server/channels/__tests__/__snapshots__/auth.js.snap
+++ b/server/channels/__tests__/__snapshots__/auth.js.snap
@@ -8,7 +8,7 @@ Array [
       "data": Object {
         "error": "Noe gikk galt under registreringen. Prøv igjen",
       },
-      "type": "AUTH_ERROR",
+      "type": "ERROR",
     },
   ],
 ]
@@ -22,7 +22,7 @@ Array [
       "data": Object {
         "error": "Validering av personlig kode feilet",
       },
-      "type": "AUTH_ERROR",
+      "type": "ERROR",
     },
   ],
 ]
@@ -36,7 +36,7 @@ Array [
       "data": Object {
         "error": "Feil pinkode",
       },
-      "type": "AUTH_ERROR",
+      "type": "ERROR",
     },
   ],
 ]
@@ -50,7 +50,7 @@ Array [
       "data": Object {
         "error": "Registreringen er ikke åpen.",
       },
-      "type": "AUTH_ERROR",
+      "type": "ERROR",
     },
   ],
 ]
@@ -64,7 +64,7 @@ Array [
       "data": Object {
         "error": "Feil personlig kode",
       },
-      "type": "AUTH_ERROR",
+      "type": "ERROR",
     },
   ],
 ]

--- a/server/channels/__tests__/__snapshots__/authAdmin.js.snap
+++ b/server/channels/__tests__/__snapshots__/authAdmin.js.snap
@@ -6,7 +6,8 @@ Array [
     "action",
     Object {
       "data": Object {
-        "error": "Ugyldig administratorpassord.",
+        "id": 0,
+        "message": "Ugyldig administratorpassord.",
       },
       "type": "ERROR",
     },
@@ -38,7 +39,8 @@ Array [
     "action",
     Object {
       "data": Object {
-        "error": "Ugyldig administratorpassord.",
+        "id": 0,
+        "message": "Ugyldig administratorpassord.",
       },
       "type": "ERROR",
     },

--- a/server/channels/__tests__/__snapshots__/authAdmin.js.snap
+++ b/server/channels/__tests__/__snapshots__/authAdmin.js.snap
@@ -8,7 +8,7 @@ Array [
       "data": Object {
         "error": "Ugyldig administratorpassord.",
       },
-      "type": "AUTH_ERROR",
+      "type": "ERROR",
     },
   ],
 ]
@@ -40,7 +40,7 @@ Array [
       "data": Object {
         "error": "Ugyldig administratorpassord.",
       },
-      "type": "AUTH_ERROR",
+      "type": "ERROR",
     },
   ],
 ]

--- a/server/channels/__tests__/__snapshots__/connection.js.snap
+++ b/server/channels/__tests__/__snapshots__/connection.js.snap
@@ -2032,7 +2032,7 @@ Array [
       "data": Object {
         "error": "Denne brukeren er ikke koblet til en generalforsamling. Vennligst logg ut og inn igjen.",
       },
-      "type": "AUTH_ERROR",
+      "type": "ERROR",
     },
   ],
   Array [

--- a/server/channels/__tests__/__snapshots__/connection.js.snap
+++ b/server/channels/__tests__/__snapshots__/connection.js.snap
@@ -353,9 +353,11 @@ Array [
   Array [
     "action",
     Object {
-      "data": Object {},
-      "error": "Noe gikk galt. Vennligst prøv igjen.",
-      "type": "issue",
+      "data": Object {
+        "id": 0,
+        "message": "Noe gikk galt. Vennligst prøv igjen.",
+      },
+      "type": "ERROR",
     },
   ],
 ]
@@ -2030,7 +2032,8 @@ Array [
     "action",
     Object {
       "data": Object {
-        "error": "Denne brukeren er ikke koblet til en generalforsamling. Vennligst logg ut og inn igjen.",
+        "id": 0,
+        "message": "Denne brukeren er ikke koblet til en generalforsamling. Vennligst logg ut og inn igjen.",
       },
       "type": "ERROR",
     },
@@ -2047,9 +2050,11 @@ Array [
   Array [
     "action",
     Object {
-      "data": Object {},
-      "error": "Noe gikk galt. Vennligst prøv igjen.",
-      "type": "issue",
+      "data": Object {
+        "id": 0,
+        "message": "Noe gikk galt. Vennligst prøv igjen.",
+      },
+      "type": "ERROR",
     },
   ],
 ]

--- a/server/channels/__tests__/__snapshots__/connection.js.snap
+++ b/server/channels/__tests__/__snapshots__/connection.js.snap
@@ -307,11 +307,10 @@ Array [
     "action",
     Object {
       "data": Object {
-        "code": "no_active_meeting",
-        "error": 1,
+        "id": 0,
         "message": "Ingen aktiv generalforsamling.",
       },
-      "type": "OPEN_MEETING",
+      "type": "ERROR",
     },
   ],
 ]
@@ -410,11 +409,11 @@ Array [
   Array [
     "action",
     Object {
-      "action": null,
-      "data": Object {},
-      "error": null,
-      "message": "Det er ingen aktive saker for øyeblikket.",
-      "type": "issue",
+      "data": Object {
+        "id": 0,
+        "message": "Det er ingen aktive saker for øyeblikket.",
+      },
+      "type": "ERROR",
     },
   ],
   Array [
@@ -1112,11 +1111,10 @@ Array [
     "action",
     Object {
       "data": Object {
-        "code": "no_active_meeting",
-        "error": 1,
+        "id": 0,
         "message": "Ingen aktiv generalforsamling.",
       },
-      "type": "OPEN_MEETING",
+      "type": "ERROR",
     },
   ],
 ]
@@ -1169,11 +1167,11 @@ Array [
   Array [
     "action",
     Object {
-      "action": null,
-      "data": Object {},
-      "error": null,
-      "message": "Det er ingen aktive saker for øyeblikket.",
-      "type": "issue",
+      "data": Object {
+        "id": 0,
+        "message": "Det er ingen aktive saker for øyeblikket.",
+      },
+      "type": "ERROR",
     },
   ],
   Array [
@@ -1662,11 +1660,10 @@ Array [
     "action",
     Object {
       "data": Object {
-        "code": "no_active_meeting",
-        "error": 1,
+        "id": 0,
         "message": "Ingen aktiv generalforsamling.",
       },
-      "type": "OPEN_MEETING",
+      "type": "ERROR",
     },
   ],
 ]
@@ -1994,11 +1991,10 @@ Array [
     "action",
     Object {
       "data": Object {
-        "code": "no_active_meeting",
-        "error": 1,
+        "id": 0,
         "message": "Ingen aktiv generalforsamling.",
       },
-      "type": "OPEN_MEETING",
+      "type": "ERROR",
     },
   ],
 ]

--- a/server/channels/__tests__/__snapshots__/issue.js.snap
+++ b/server/channels/__tests__/__snapshots__/issue.js.snap
@@ -309,7 +309,7 @@ Array [
     Object {
       "data": Object {
         "id": 0,
-        "message": "Closing issue failed",
+        "message": "Stenging av sak feilet",
       },
       "type": "ERROR",
     },
@@ -534,7 +534,7 @@ Array [
     Object {
       "data": Object {
         "id": 0,
-        "message": "Adding new question failed",
+        "message": "Opprettelse av sak feilet",
       },
       "type": "ERROR",
     },

--- a/server/channels/__tests__/__snapshots__/issue.js.snap
+++ b/server/channels/__tests__/__snapshots__/issue.js.snap
@@ -307,9 +307,11 @@ Array [
   Array [
     "action",
     Object {
-      "data": Object {},
-      "error": "Closing issue failed",
-      "type": "issue",
+      "data": Object {
+        "id": 0,
+        "message": "Closing issue failed",
+      },
+      "type": "ERROR",
     },
   ],
 ]
@@ -530,9 +532,11 @@ Array [
   Array [
     "action",
     Object {
-      "data": Object {},
-      "error": "Adding new question failed",
-      "type": "issue",
+      "data": Object {
+        "id": 0,
+        "message": "Adding new question failed",
+      },
+      "type": "ERROR",
     },
   ],
 ]

--- a/server/channels/__tests__/__snapshots__/vote.js.snap
+++ b/server/channels/__tests__/__snapshots__/vote.js.snap
@@ -20,9 +20,11 @@ Array [
   Array [
     "action",
     Object {
-      "data": Object {},
-      "error": "You do not have the right to vote",
-      "type": "ADD_VOTE",
+      "data": Object {
+        "id": 0,
+        "message": "Du har ikke stemmerett",
+      },
+      "type": "ERROR",
     },
   ],
 ]
@@ -106,9 +108,11 @@ Array [
   Array [
     "action",
     Object {
-      "data": Object {},
-      "error": "Storing vote failed.",
-      "type": "ADD_VOTE",
+      "data": Object {
+        "id": 0,
+        "message": "Du har ikke stemmerett",
+      },
+      "type": "ERROR",
     },
   ],
 ]

--- a/server/channels/__tests__/__snapshots__/vote.js.snap
+++ b/server/channels/__tests__/__snapshots__/vote.js.snap
@@ -5,9 +5,11 @@ Array [
   Array [
     "action",
     Object {
-      "data": Object {},
-      "error": "Du er ikke registert",
-      "type": "ADD_VOTE",
+      "data": Object {
+        "id": 0,
+        "message": "Du er ikke registert",
+      },
+      "type": "ERROR",
     },
   ],
 ]
@@ -19,7 +21,7 @@ Array [
     "action",
     Object {
       "data": Object {
-        "id": 2,
+        "id": 0,
         "message": "User does not have the required permissions.",
       },
       "type": "ERROR",
@@ -76,9 +78,11 @@ Array [
   Array [
     "action",
     Object {
-      "data": Object {},
-      "error": "Du er ikke registert",
-      "type": "ADD_VOTE",
+      "data": Object {
+        "id": 0,
+        "message": "Du er ikke registert",
+      },
+      "type": "ERROR",
     },
   ],
 ]

--- a/server/channels/__tests__/__snapshots__/vote.js.snap
+++ b/server/channels/__tests__/__snapshots__/vote.js.snap
@@ -22,7 +22,7 @@ Array [
     Object {
       "data": Object {
         "id": 0,
-        "message": "User does not have the required permissions.",
+        "message": "Brukeren har ikke riktig rettigheter",
       },
       "type": "ERROR",
     },
@@ -95,7 +95,7 @@ Array [
     Object {
       "data": Object {
         "id": 0,
-        "message": "User does not have the required permissions.",
+        "message": "Brukeren har ikke riktig rettigheter",
       },
       "type": "ERROR",
     },

--- a/server/channels/__tests__/__snapshots__/vote.js.snap
+++ b/server/channels/__tests__/__snapshots__/vote.js.snap
@@ -18,9 +18,11 @@ Array [
   Array [
     "action",
     Object {
-      "data": Object {},
-      "error": "User does not have the required permissions.",
-      "type": "ADD_VOTE",
+      "data": Object {
+        "id": 2,
+        "message": "User does not have the required permissions.",
+      },
+      "type": "ERROR",
     },
   ],
 ]
@@ -87,9 +89,11 @@ Array [
   Array [
     "action",
     Object {
-      "data": Object {},
-      "error": "Storing vote failed.",
-      "type": "ADD_VOTE",
+      "data": Object {
+        "id": 0,
+        "message": "User does not have the required permissions.",
+      },
+      "type": "ERROR",
     },
   ],
 ]

--- a/server/channels/admin/authAdmin.js
+++ b/server/channels/admin/authAdmin.js
@@ -7,7 +7,7 @@ const {
   ADMIN_CREATE_GENFORS,
   ADMIN_LOGIN,
   AUTH_SIGNED_IN } = require('../../../common/actionTypes/auth');
-const { AUTH_ERROR } = require('../../../common/actionTypes/error');
+const { ERROR } = require('../../../common/actionTypes/error');
 const permissionLevel = require('../../../common/auth/permissions');
 
 
@@ -33,7 +33,7 @@ const adminLogin = async (socket, data) => {
     });
   } else {
     logger.info(`'${socket.request.user.name}' tried to authenticate as admin using admin password.`);
-    emit(socket, AUTH_ERROR, { error: 'Ugyldig administratorpassord.' });
+    emit(socket, ERROR, { error: 'Ugyldig administratorpassord.' });
   }
 };
 
@@ -44,7 +44,7 @@ const createGenfors = async (socket, data) => {
     logger.info('Created genfors by administrative request.', { title });
   } else {
     logger.warn('Someone tried to authenticate as administrator.', { title });
-    emit(socket, AUTH_ERROR, { error: 'Ugyldig administratorpassord.' });
+    emit(socket, ERROR, { error: 'Ugyldig administratorpassord.' });
   }
 };
 

--- a/server/channels/admin/authAdmin.js
+++ b/server/channels/admin/authAdmin.js
@@ -1,4 +1,4 @@
-const { emit } = require('../../utils');
+const { emit, emitError } = require('../../utils');
 const { addGenfors } = require('../../managers/meeting');
 const { setUserPermissions } = require('../../managers/user');
 const logger = require('../../logging');
@@ -7,7 +7,6 @@ const {
   ADMIN_CREATE_GENFORS,
   ADMIN_LOGIN,
   AUTH_SIGNED_IN } = require('../../../common/actionTypes/auth');
-const { ERROR } = require('../../../common/actionTypes/error');
 const permissionLevel = require('../../../common/auth/permissions');
 
 
@@ -33,7 +32,7 @@ const adminLogin = async (socket, data) => {
     });
   } else {
     logger.info(`'${socket.request.user.name}' tried to authenticate as admin using admin password.`);
-    emit(socket, ERROR, { error: 'Ugyldig administratorpassord.' });
+    emitError(socket, new Error('Ugyldig administratorpassord.'));
   }
 };
 
@@ -44,7 +43,7 @@ const createGenfors = async (socket, data) => {
     logger.info('Created genfors by administrative request.', { title });
   } else {
     logger.warn('Someone tried to authenticate as administrator.', { title });
-    emit(socket, ERROR, { error: 'Ugyldig administratorpassord.' });
+    emitError(socket, new Error('Ugyldig administratorpassord.'));
   }
 };
 

--- a/server/channels/admin/user/__tests__/__snapshots__/userlist.js.snap
+++ b/server/channels/admin/user/__tests__/__snapshots__/userlist.js.snap
@@ -7,9 +7,11 @@ Array [
   Array [
     "action",
     Object {
-      "data": Array [],
-      "error": "Could not fetch user list.",
-      "type": "USER_LIST",
+      "data": Object {
+        "id": 0,
+        "message": "Could not fetch user list.",
+      },
+      "type": "ERROR",
     },
   ],
 ]

--- a/server/channels/admin/user/__tests__/__snapshots__/userlist.js.snap
+++ b/server/channels/admin/user/__tests__/__snapshots__/userlist.js.snap
@@ -9,7 +9,7 @@ Array [
     Object {
       "data": Object {
         "id": 0,
-        "message": "Could not fetch user list.",
+        "message": "Klarte ikke hente brukerliste",
       },
       "type": "ERROR",
     },

--- a/server/channels/admin/user/toggle_vote.js
+++ b/server/channels/admin/user/toggle_vote.js
@@ -29,7 +29,7 @@ const toggleCanVote = async (socket, data) => {
     broadcastAndEmit(socket, TOGGLED_CAN_VOTE, user);
   }).catch((err) => {
     logger.error('Retrieving user failed.', err);
-    emitError(socket, new Error('Could not fetch user list.'));
+    emitError(socket, new Error('Noe gikk galt under oppdatering av stemmeberettiget'));
   });
 };
 

--- a/server/channels/admin/user/toggle_vote.js
+++ b/server/channels/admin/user/toggle_vote.js
@@ -1,5 +1,4 @@
-const { broadcastAndEmit } = require('../../../utils');
-const emit = require('../../../utils').emit;
+const { broadcastAndEmit, emitError } = require('../../../utils');
 const logger = require('../../../logging');
 
 const { updateUserById } = require('../../../models/user');
@@ -30,9 +29,7 @@ const toggleCanVote = async (socket, data) => {
     broadcastAndEmit(socket, TOGGLED_CAN_VOTE, user);
   }).catch((err) => {
     logger.error('Retrieving user failed.', err);
-    emit(socket, TOGGLED_CAN_VOTE, [], {
-      error: 'Could not fetch user list.',
-    });
+    emitError(socket, new Error('Could not fetch user list.'));
   });
 };
 

--- a/server/channels/admin/user/userlist.js
+++ b/server/channels/admin/user/userlist.js
@@ -1,4 +1,4 @@
-const emit = require('../../../utils').emit;
+const { emit, emitError } = require('../../../utils');
 const logger = require('../../../logging');
 
 const { getActiveGenfors } = require('../../../models/meeting');
@@ -14,9 +14,7 @@ const requestUserList = async (socket) => {
       emit(socket, USER_LIST, users);
     }).catch((err) => {
       logger.error('Retrieving users failed.', err);
-      emit(socket, USER_LIST, [], {
-        error: 'Could not fetch user list.',
-      });
+      emitError(socket, new Error('Could not fetch user list.'));
     });
   }).catch((err) => {
     logger.error('Retrieving current active genfors failed', err);

--- a/server/channels/admin/user/userlist.js
+++ b/server/channels/admin/user/userlist.js
@@ -14,7 +14,7 @@ const requestUserList = async (socket) => {
       emit(socket, USER_LIST, users);
     }).catch((err) => {
       logger.error('Retrieving users failed.', err);
-      emitError(socket, new Error('Could not fetch user list.'));
+      emitError(socket, new Error('Klarte ikke hente brukerliste'));
     });
   }).catch((err) => {
     logger.error('Retrieving current active genfors failed', err);

--- a/server/channels/auth.js
+++ b/server/channels/auth.js
@@ -6,19 +6,19 @@ const { validatePasswordHash } = require('../managers/user');
 const logger = require('../logging');
 
 const { AUTH_REGISTER, AUTH_REGISTERED } = require('../../common/actionTypes/auth');
-const { AUTH_ERROR } = require('../../common/actionTypes/error');
+const { ERROR } = require('../../common/actionTypes/error');
 
 const register = async (socket, data) => {
   const { pin, passwordHash } = data;
   const username = socket.request.user.onlinewebId;
   const genfors = await getActiveGenfors();
   if (!genfors.registrationOpen) {
-    emit(socket, AUTH_ERROR, { error: 'Registreringen er ikke åpen.' });
+    emit(socket, ERROR, { error: 'Registreringen er ikke åpen.' });
     return;
   }
   if (!await validatePin(pin)) {
     logger.silly('User failed pin code', { username, pin });
-    emit(socket, AUTH_ERROR, { error: 'Feil pinkode' });
+    emit(socket, ERROR, { error: 'Feil pinkode' });
     return;
   }
   const { completedRegistration } = socket.request.user;
@@ -28,13 +28,13 @@ const register = async (socket, data) => {
       validPasswordHash = await validatePasswordHash(socket.request.user, passwordHash);
     } catch (err) {
       logger.debug('Failed to validate user', { username, err });
-      emit(socket, AUTH_ERROR, { error: 'Validering av personlig kode feilet' });
+      emit(socket, ERROR, { error: 'Validering av personlig kode feilet' });
       return;
     }
     if (validPasswordHash) {
       emit(socket, AUTH_REGISTERED, { registered: true });
     } else {
-      emit(socket, AUTH_ERROR, { error: 'Feil personlig kode' });
+      emit(socket, ERROR, { error: 'Feil personlig kode' });
     }
     return;
   }
@@ -42,7 +42,7 @@ const register = async (socket, data) => {
     await addAnonymousUser(username, passwordHash);
   } catch (err) {
     logger.debug('Failed to register user', { username, err });
-    emit(socket, AUTH_ERROR, { error: 'Noe gikk galt under registreringen. Prøv igjen' });
+    emit(socket, ERROR, { error: 'Noe gikk galt under registreringen. Prøv igjen' });
     return;
   }
   logger.silly('Successfully registered', { username });

--- a/server/channels/auth.js
+++ b/server/channels/auth.js
@@ -1,4 +1,4 @@
-const { emit } = require('../utils');
+const { emit, emitError } = require('../utils');
 const { getActiveGenfors } = require('../models/meeting');
 const { validatePin } = require('../managers/meeting');
 const { addAnonymousUser } = require('../managers/user');
@@ -6,19 +6,18 @@ const { validatePasswordHash } = require('../managers/user');
 const logger = require('../logging');
 
 const { AUTH_REGISTER, AUTH_REGISTERED } = require('../../common/actionTypes/auth');
-const { ERROR } = require('../../common/actionTypes/error');
 
 const register = async (socket, data) => {
   const { pin, passwordHash } = data;
   const username = socket.request.user.onlinewebId;
   const genfors = await getActiveGenfors();
   if (!genfors.registrationOpen) {
-    emit(socket, ERROR, { error: 'Registreringen er ikke åpen.' });
+    emitError(socket, new Error('Registreringen er ikke åpen.'));
     return;
   }
   if (!await validatePin(pin)) {
     logger.silly('User failed pin code', { username, pin });
-    emit(socket, ERROR, { error: 'Feil pinkode' });
+    emitError(socket, new Error('Feil pinkode'));
     return;
   }
   const { completedRegistration } = socket.request.user;
@@ -28,13 +27,13 @@ const register = async (socket, data) => {
       validPasswordHash = await validatePasswordHash(socket.request.user, passwordHash);
     } catch (err) {
       logger.debug('Failed to validate user', { username, err });
-      emit(socket, ERROR, { error: 'Validering av personlig kode feilet' });
+      emitError(socket, new Error('Validering av personlig kode feilet'));
       return;
     }
     if (validPasswordHash) {
       emit(socket, AUTH_REGISTERED, { registered: true });
     } else {
-      emit(socket, ERROR, { error: 'Feil personlig kode' });
+      emitError(socket, new Error('Feil personlig kode'));
     }
     return;
   }
@@ -42,7 +41,7 @@ const register = async (socket, data) => {
     await addAnonymousUser(username, passwordHash);
   } catch (err) {
     logger.debug('Failed to register user', { username, err });
-    emit(socket, ERROR, { error: 'Noe gikk galt under registreringen. Prøv igjen' });
+    emitError(socket, new Error('Noe gikk galt under registreringen. Prøv igjen'));
     return;
   }
   logger.silly('Successfully registered', { username });

--- a/server/channels/connection.js
+++ b/server/channels/connection.js
@@ -1,4 +1,4 @@
-const emit = require('../utils').emit;
+const { emit, emitError } = require('../utils');
 const logger = require('../logging');
 
 const getActiveGenfors = require('../models/meeting').getActiveGenfors;
@@ -11,7 +11,6 @@ const { getAnonymousUser } = require('../models/user');
 const { validatePasswordHash } = require('../managers/user');
 const { getPublicIssueWithVotes } = require('../managers/issue');
 
-const { ERROR } = require('../../common/actionTypes/error');
 const { VERSION } = require('../../common/actionTypes/version');
 const { CLOSE_ISSUE, OPEN_ISSUE } = require('../../common/actionTypes/issues');
 const { OPEN_MEETING } = require('../../common/actionTypes/meeting');
@@ -53,7 +52,7 @@ const emitUserData = async (socket) => {
     });
 
     if (!user.genfors) {
-      emit(socket, ERROR, { error: 'Denne brukeren er ikke koblet til en generalforsamling. Vennligst logg ut og inn igjen.' });
+      emitError(socket, new Error('Denne brukeren er ikke koblet til en generalforsamling. Vennligst logg ut og inn igjen.'));
     }
 
     let validPasswordHash = false;
@@ -138,9 +137,7 @@ const emitGenforsData = async (socket) => {
     await emitIssueBacklog(socket, meeting);
   } catch (err) {
     logger.error('Something went wrong when fetching active genfors.', err);
-    emit(socket, 'issue', {}, {
-      error: 'Noe gikk galt. Vennligst prøv igjen.',
-    });
+    emitError(socket, new Error('Noe gikk galt. Vennligst prøv igjen.'));
   }
 };
 

--- a/server/channels/connection.js
+++ b/server/channels/connection.js
@@ -11,7 +11,7 @@ const { getAnonymousUser } = require('../models/user');
 const { validatePasswordHash } = require('../managers/user');
 const { getPublicIssueWithVotes } = require('../managers/issue');
 
-const { AUTH_ERROR } = require('../../common/actionTypes/error');
+const { ERROR } = require('../../common/actionTypes/error');
 const { VERSION } = require('../../common/actionTypes/version');
 const { CLOSE_ISSUE, OPEN_ISSUE } = require('../../common/actionTypes/issues');
 const { OPEN_MEETING } = require('../../common/actionTypes/meeting');
@@ -53,7 +53,7 @@ const emitUserData = async (socket) => {
     });
 
     if (!user.genfors) {
-      emit(socket, AUTH_ERROR, { error: 'Denne brukeren er ikke koblet til en generalforsamling. Vennligst logg ut og inn igjen.' });
+      emit(socket, ERROR, { error: 'Denne brukeren er ikke koblet til en generalforsamling. Vennligst logg ut og inn igjen.' });
     }
 
     let validPasswordHash = false;

--- a/server/channels/connection.js
+++ b/server/channels/connection.js
@@ -28,11 +28,7 @@ const {
 
 const emitNoActiveIssue = (socket) => {
   logger.debug('No active issue.');
-  emit(socket, 'issue', {}, {
-    action: null,
-    error: null,
-    message: 'Det er ingen aktive saker for øyeblikket.',
-  });
+  emitError(socket, new Error('Det er ingen aktive saker for øyeblikket.'));
 };
 
 // eslint-disable-next-line global-require
@@ -127,7 +123,7 @@ const emitGenforsData = async (socket) => {
   try {
     const meeting = await getActiveGenfors();
     if (!meeting) {
-      emit(socket, OPEN_MEETING, { error: 1, code: 'no_active_meeting', message: 'Ingen aktiv generalforsamling.' });
+      emitError(socket, new Error('Ingen aktiv generalforsamling.'));
       return;
     }
     emit(socket, OPEN_MEETING, meeting);

--- a/server/channels/issue.js
+++ b/server/channels/issue.js
@@ -20,7 +20,7 @@ const createIssue = async (socket, payload) => {
     broadcast(socket, ENABLE_VOTING);
   }).catch((err) => {
     logger.error('Adding new question failed.', err);
-    emitError(socket, new Error('Adding new question failed'));
+    emitError(socket, new Error('Opprettelse av sak feilet'));
   });
 };
 
@@ -46,7 +46,7 @@ const closeIssue = async (socket, payload) => {
   })
   .catch((err) => {
     logger.error('closing issue failed', err);
-    emitError(socket, new Error('Closing issue failed'));
+    emitError(socket, new Error('Stenging av sak feilet'));
   });
 };
 

--- a/server/channels/issue.js
+++ b/server/channels/issue.js
@@ -1,4 +1,4 @@
-const { adminBroadcast, broadcast, broadcastAndEmit, emit } = require('../utils');
+const { adminBroadcast, broadcast, broadcastAndEmit, emit, emitError } = require('../utils');
 const logger = require('../logging');
 
 const { addIssue, endIssue, deleteIssue, getPublicIssueWithVotes } = require('../managers/issue');
@@ -20,9 +20,7 @@ const createIssue = async (socket, payload) => {
     broadcast(socket, ENABLE_VOTING);
   }).catch((err) => {
     logger.error('Adding new question failed.', err);
-    emit(socket, 'issue', {}, {
-      error: 'Adding new question failed',
-    });
+    emitError(socket, new Error('Adding new question failed'));
   });
 };
 
@@ -48,9 +46,7 @@ const closeIssue = async (socket, payload) => {
   })
   .catch((err) => {
     logger.error('closing issue failed', err);
-    emit(socket, 'issue', {}, {
-      error: 'Closing issue failed',
-    });
+    emitError(socket, new Error('Closing issue failed'));
   });
 };
 

--- a/server/channels/vote.js
+++ b/server/channels/vote.js
@@ -18,9 +18,7 @@ const checkRegistered = async (socket) => {
   const { passwordHash } = socket.request.headers.cookie;
   const registered = await isRegistered(user, passwordHash);
   if (!registered) {
-    emit(socket, SEND_VOTE, {}, {
-      error: 'Du er ikke registert',
-    });
+    emitError(socket, new Error('Du er ikke registert'));
     return false;
   }
   return true;

--- a/server/channels/vote.js
+++ b/server/channels/vote.js
@@ -1,4 +1,4 @@
-const { broadcastAndEmit, emit } = require('../utils');
+const { broadcastAndEmit, emit, emitError } = require('../utils');
 const logger = require('../logging');
 
 const { addVote, generatePublicVote } = require('../managers/vote');
@@ -42,9 +42,7 @@ const submitRegularVote = async (socket, data) => {
     emit(socket, VOTING_STATE, { voted: true });
   } catch (err) {
     logger.error('Storing new vote failed.', err);
-    emit(socket, SEND_VOTE, {}, {
-      error: 'Storing vote failed.',
-    });
+    emitError(socket, err);
   }
 };
 
@@ -65,9 +63,7 @@ const submitAnonymousVote = async (socket, data) => {
     emit(socket, VOTING_STATE, { voted: true });
   } catch (err) {
     logger.error('Storing new anonymous vote failed.', err);
-    emit(socket, SEND_VOTE, {}, {
-      error: err.message,
-    });
+    emitError(socket, err);
   }
 };
 

--- a/server/managers/meeting.js
+++ b/server/managers/meeting.js
@@ -31,7 +31,7 @@ async function canEdit(securityLevel, user, genforsId) {
     userpermission: user.permissions,
     clearance: securityLevel,
   });
-  throw new Error('User does not have the required permissions.');
+  throw new Error('Brukeren har ikke riktig rettigheter');
 }
 
 

--- a/server/managers/vote.js
+++ b/server/managers/vote.js
@@ -16,7 +16,7 @@ function addVote(issueId, user, alternative, voter) {
       }
       if (!user.canVote) {
         logger.warn('Tried to vote without the right to vote!', { issueId, user: user.onlinewebId });
-        reject(new Error('You do not have the right to vote'));
+        reject(new Error('Du har ikke stemmerett'));
         return;
       }
       logger.silly('Checking permissions.', { issueId, user: user.onlinewebId });

--- a/server/utils.js
+++ b/server/utils.js
@@ -1,3 +1,5 @@
+const { ERROR } = require('../common/actionTypes/error');
+
 const mergePermanentAndMetadata = (perm, meta) => Object.assign(perm, meta);
 
 const createSocketObject = (channel, payload, metadata) => {
@@ -25,9 +27,20 @@ const adminBroadcast = (socket, channel, payload, metadata) => {
   socket.to('admin').emit('action', createSocketObject(channel, payload, metadata));
 };
 
+let errorCounter = 0;
+
+const emitError = (socket, error) => {
+  emit(socket, ERROR, {
+    message: error.message,
+    id: errorCounter,
+  });
+  errorCounter += 1;
+};
+
 module.exports = {
   broadcast,
   emit,
   broadcastAndEmit,
   adminBroadcast,
+  emitError,
 };

--- a/server/utils.js
+++ b/server/utils.js
@@ -34,7 +34,11 @@ const emitError = (socket, error) => {
     message: error.message,
     id: errorCounter,
   });
-  errorCounter += 1;
+
+  // Hack to produce deterministic snapshots
+  if (process.env.NODE_ENV !== 'test') {
+    errorCounter += 1;
+  }
 };
 
 module.exports = {


### PR DESCRIPTION
- We can now show multiple errors and dismiss them individually
- Error format standardized with util function `emitError`
- Translated some errors to Norwegian(feel free to suggest better translations)

I think we're still missing some error feedback as sometimes the catch block only consists of a log statement. 

Fixes #189