### PR TITLE
Tell users they are currently not allowed to vote

### DIFF
--- a/server/channels/__tests__/__snapshots__/vote.js.snap
+++ b/server/channels/__tests__/__snapshots__/vote.js.snap
@@ -22,7 +22,7 @@ Array [
     Object {
       "data": Object {
         "id": 0,
-        "message": "Du har ikke stemmerett",
+        "message": "Du er ikke stemmeberettiget",
       },
       "type": "ERROR",
     },
@@ -171,7 +171,7 @@ Array [
     Object {
       "data": Object {
         "id": 0,
-        "message": "Du har ikke stemmerett",
+        "message": "Du er ikke stemmeberettiget",
       },
       "type": "ERROR",
     },

--- a/server/managers/vote.js
+++ b/server/managers/vote.js
@@ -19,7 +19,7 @@ async function addVote(issueId, user, alternative, voter) {
   }
   if (!user.canVote) {
     logger.warn('Tried to vote without the right to vote!', { issueId, user: user.onlinewebId });
-    throw new Error('Du har ikke stemmerett');
+    throw new Error('Du er ikke stemmeberettiget');
   }
   logger.silly('Checking permissions.', { issueId, user: user.onlinewebId });
   try {


### PR DESCRIPTION
Tells users they are not allowed to vote _right now_ if `canVote` is false (this is used to toggle if you should be able to vote, e.g. during breaks or when leaving the voting room) rather than telling them that they are not allowed to vote (which could be misinterpreted as _at all_).