### PR TITLE
Prevent voting on invalid alternatives

### DIFF
--- a/client/src/components/App/VotingMenu.js
+++ b/client/src/components/App/VotingMenu.js
@@ -31,6 +31,7 @@ class VotingMenu extends React.Component {
     );
     this.setState({
       displayVote: false,
+      selectedVote: null,
     });
   }
 

--- a/server/channels/__tests__/__snapshots__/vote.js.snap
+++ b/server/channels/__tests__/__snapshots__/vote.js.snap
@@ -134,6 +134,21 @@ Array [
 ]
 `;
 
+exports[`submitRegularVote emits error when trying to vote on non-existing alternative 1`] = `
+Array [
+  Array [
+    "action",
+    Object {
+      "data": Object {
+        "id": 0,
+        "message": "Alternativet du stemte på finnes ikke",
+      },
+      "type": "ERROR",
+    },
+  ],
+]
+`;
+
 exports[`submitRegularVote emits error when trying to vote twice 1`] = `
 Array [
   Array [

--- a/server/channels/__tests__/vote.js
+++ b/server/channels/__tests__/vote.js
@@ -27,9 +27,10 @@ beforeEach(() => {
   }));
 });
 
-const generateData = () => ({
+const generateData = data => ({
   issue: '1',
   alternative: '1',
+  ...data,
 });
 
 
@@ -114,6 +115,17 @@ describe('submitRegularVote', () => {
     const socket = generateSocket({ completedRegistration: true });
 
     await submitRegularVote(socket, generateData());
+
+    expect(socket.emit.mock.calls).toMatchSnapshot();
+    expect(socket.broadcast.emit.mock.calls).toEqual([]);
+  });
+
+  it('emits error when trying to vote on non-existing alternative', async () => {
+    const socket = generateSocket({
+      completedRegistration: true,
+    });
+
+    await submitRegularVote(socket, generateData({ alternative: '-1' }));
 
     expect(socket.emit.mock.calls).toMatchSnapshot();
     expect(socket.broadcast.emit.mock.calls).toEqual([]);

--- a/server/managers/vote.js
+++ b/server/managers/vote.js
@@ -24,6 +24,10 @@ async function addVote(issueId, user, alternative, voter) {
   logger.silly('Checking permissions.', { issueId, user: user.onlinewebId });
   try {
     await canEdit(permissionLevel.CAN_VOTE, user, issue.genfors);
+    const validAlternative = issue.alternatives.some(alt => alt.id === alternative);
+    if (!validAlternative) {
+      throw new Error('Alternativet du stemte på finnes ikke');
+    }
     const alreadyVoted = await haveIVoted(issueId, voter);
     if (!alreadyVoted) {
       const vote = createVote(voter, issueId, alternative);


### PR DESCRIPTION
Because of several bugs users were able to vote on a new issue using an old alternative. 

Fortunately this did not affect the results except that the votes did not sum up to 100%. 