### PR TITLE
Minor tweaks to visuals, can deselect selected vote

### DIFF
--- a/client/src/components/Alternative.css
+++ b/client/src/components/Alternative.css
@@ -1,7 +1,7 @@
 .alternative {
   display: flex;
   margin: 0.5rem 0;
-  background: #6b71a5;
+  background: #666a99;
   color: #fff;
   transition: all 0.3s;
   border-radius: 2px;
@@ -15,15 +15,15 @@
 }
 
 .alternative:hover {
-  background: #8d93c7;
+  background: #8588ad;
 }
 
 .selected {
-  background: #4d516f;
+  background: #474a6b;
 }
 
 .selected:hover {
-  background: #575c7d;
+  background: #52557a;
 }
 
 .disabled {

--- a/client/src/components/App/VotingMenu.js
+++ b/client/src/components/App/VotingMenu.js
@@ -67,7 +67,7 @@ class VotingMenu extends React.Component {
           onClick={() => this.handleClick()}
           disabled={canVote || !votingInProgress}
         >
-          {hasVoted ? 'Du har allerede stemt' : 'Avgi stemme'}
+          {hasVoted ? 'Du har stemt' : 'Avgi stemme'}
         </Button>}
         {hasVoted && (
           <Button

--- a/client/src/components/App/VotingMenu.js
+++ b/client/src/components/App/VotingMenu.js
@@ -19,8 +19,10 @@ class VotingMenu extends React.Component {
   }
 
   handleChange(event) {
+    const newVote = this.state.selectedVote === event.currentTarget.value
+      ? null : event.currentTarget.value;
     this.setState({
-      selectedVote: event.currentTarget.value,
+      selectedVote: newVote,
     });
   }
 

--- a/client/src/components/Button.css
+++ b/client/src/components/Button.css
@@ -37,9 +37,10 @@
 }
 
 .button:disabled {
-  background: #747586;
+  background: #a0a0ac;
   color: white;
-  cursor: not-allowed
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 .size-sm {

--- a/client/src/components/Button.css
+++ b/client/src/components/Button.css
@@ -19,7 +19,7 @@
 
 .background {
   color: #fff;
-  background: #686b92;
+  background: #666a99;
   font-weight: bold;
   border: 1px solid rgba(0, 0, 0, 0.04);
   border-radius: 2px;
@@ -29,15 +29,15 @@
 
 .background:hover {
   color: #fff;
-  background: #888db5;
+  background: #8588ad;
 }
 
 .background:active {
-  background: #abaec5;
+  background: #a3a6c2;
 }
 
 .button:disabled {
-  background: #a0a0ac;
+  background: #9497b8;
   color: white;
   cursor: not-allowed;
   box-shadow: none;

--- a/client/src/components/VoteCounter.css
+++ b/client/src/components/VoteCounter.css
@@ -11,7 +11,7 @@
 }
 
 .progress {
-  background: #6b71a5;
+  background: #666a99;
   box-shadow: inset 0 -1px 1px 0 #272b4c;
   height: 100%;
 }


### PR DESCRIPTION
Before on disabled vote button
![screenshot from 2017-10-30 19-01-22](https://user-images.githubusercontent.com/14059677/32189730-f4010a94-bdab-11e7-84d8-86737eea3897.png)

After on disabled vote button
![screenshot from 2017-10-30 19-00-56](https://user-images.githubusercontent.com/14059677/32189729-f3e218fa-bdab-11e7-9b40-6b08b76368d2.png)

---

Before on selected vote contrast
![screenshot from 2017-10-30 19-50-19](https://user-images.githubusercontent.com/14059677/32189731-f424fc9c-bdab-11e7-8195-bbfae0d48fc0.png)

After on selected vote contrast
![screenshot from 2017-10-30 19-50-54](https://user-images.githubusercontent.com/14059677/32189732-f449beba-bdab-11e7-9141-1431435b89d0.png)

Do you see the difference? I don't. I'm not even sure that those are really before-and-after, or if they are after-and-before. I concluded that the issue is a won't-fix from me, so I just cleaned up color codes in general.

Also resolves #233. 