### PR TITLE
Add OpenID as authentication mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ To configure the app to use the OAuth2 provider, set the following values using 
 
 _If running the OAuth2 provider in [onlineweb4](/dotkom/onlineweb4) locally, remember that webpack uses port 3000 by default, so you'll likely have to use another port for super-duper-fiesta._
 
+### OpenID Connect
+
+Authentication can be done through OpenID Connect.
+
+This requires an OpenID Client ID as well as an OpenID Provider capable of providing the "onlineweb4" claim. [source](https://github.com/dotkom/onlineweb4/blob/develop/apps/oidc_provider/claims.py#L33)
+
+| Key | Description | Example | Default |
+| --- | ---         | ---     | ---     |
+| `SDF_OIDC` | Enable OpenID Connect | `true` | `` |
+| `SDF_OIDC_PROVIDER` | OpenID Connect Provider (Issuer) | `http://127.0.0.1:8000/openid` | `` |
+| `SDF_OIDC_CLIENT_ID` | ClientID of an OIDC client on OIDC provider | `123456` | `` |
+| `SDF_OIDC_REDIRECT_URI` | Redirect URI back to SDF | `http://127.0.0.1:8080/openid-auth` | `` |
 
 ## WIP Screenshots
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "mongoose": "^4.7.6",
     "node-fetch": "^1.6.3",
     "normalize.css": "^6.0.0",
+    "openid-client": "^1.19.3",
     "passport": "^0.3.2",
     "passport-oauth2": "^1.4.0",
     "passport.socketio": "^3.7.0",

--- a/server/auth/__tests__/index.js
+++ b/server/auth/__tests__/index.js
@@ -1,14 +1,21 @@
-jest.mock('../../models/user');
 const request = require('supertest');
 const express = require('express');
+const session = require('express-session');
 const auth = require('../index');
 const authProviderConfig = require('../conf');
+const { Issuer } = require('openid-client');
 
-const server = express();
+Issuer.discover = () => new Issuer({
+  issuer: process.env.SDF_OIDC_PROVIDER,
+  authorization_endpoint: `${process.env.SDF_OIDC_PROVIDER}/authorize`,
+});
+
+let server;
 let app;
 
 describe('auth', () => {
   beforeAll(async () => {
+    server = express();
     app = await auth(server);
   });
 
@@ -30,5 +37,68 @@ describe('auth', () => {
         location: '/',
       }),
     );
+  });
+});
+
+async function getApp() {
+  server = express();
+  server.use(session({
+    resave: false,
+    saveUninitialized: true,
+    secret: 'super secret',
+  }));
+  return auth(server);
+}
+
+describe('openid enabled', () => {
+  beforeEach(async () => {
+    process.env.SDF_OIDC = 'true';
+    process.env.SDF_OIDC_PROVIDER = 'http://example.org/openid';
+    process.env.SDF_OIDC_CLIENT_ID = '123456';
+  });
+
+  afterEach(() => {
+    process.env.SDF_OIDC = '';
+    process.env.SDF_OIDC_PROVIDER = '';
+    process.env.SDF_OIDC_CLIENT_ID = '';
+  });
+
+  it('redirects to OpenID provider when OIDC enabled', async () => {
+    app = await getApp();
+    const response = await request(app).get('/openid-login');
+    expect(response.statusCode).toEqual(302);
+    expect(response.header).toEqual(
+      expect.objectContaining({
+        location: expect.stringContaining(process.env.SDF_OIDC_PROVIDER),
+      }),
+    );
+  });
+
+  it('does not add routes if missing configuration details', async () => {
+    process.env.SDF_OIDC_PROVIDER = '';
+    app = await getApp();
+
+    const response = await request(app).get('/openid-login');
+    expect(response.statusCode).toEqual(404);
+  });
+
+  it('does not add routes if OpenID autodiscovery fails', async () => {
+    Issuer.discover = () => { throw Error(); };
+    app = await getApp();
+
+    const response = await request(app).get('/openid-login');
+    expect(response.statusCode).toEqual(404);
+  });
+});
+
+describe('openid disabled', () => {
+  beforeEach(async () => {
+    process.env.SDF_OIDC = '';
+    app = await getApp();
+  });
+
+  it('does not add routes if OpenID not enabled', async () => {
+    const response = await request(app).get('/openid-login');
+    expect(response.statusCode).toEqual(404);
   });
 });

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -1,5 +1,6 @@
 const logger = require('../logging');
 const passport = require('passport');
+const { setupOIDC } = require('./oidc');
 
 const getUserById = require('../models/user').getUserById;
 
@@ -25,5 +26,13 @@ module.exports = async (app) => {
   app.get('/auth', passport.authenticate('oauth2', { callback: true }), (req, res) => {
     res.redirect('/');
   });
+  if (process.env.SDF_OIDC && process.env.SDF_OIDC.toLowerCase() === 'true') {
+    const success = await setupOIDC();
+    if (success) {
+      app.get('/openid-login', passport.authenticate('oidc'));
+      app.get('/openid-auth', passport.authenticate('oidc', { successRedirect: '/', failureRedirect: '/openid-login' }));
+    }
+    return app;
+  }
   return app;
 };

--- a/server/auth/oidc.js
+++ b/server/auth/oidc.js
@@ -12,7 +12,8 @@ async function getOIDCClient() {
   const clientId = process.env.SDF_OIDC_CLIENT_ID;
 
   if (!provider || !clientId) {
-    logger.crit('Did not provide "SDF_OIDC_PROVIDER" and "SDF_OIDC_CLIENT_ID" when using OIDC.');
+    logger.error('Did not provide "SDF_OIDC_PROVIDER" and "SDF_OIDC_CLIENT_ID" when using OIDC.');
+    throw Error('Did not provide "SDF_OIDC_PROVIDER" and "SDF_OIDC_CLIENT_ID" when using OIDC.');
   }
 
   logger.debug('Discovering OIDC issuer.', { provider });
@@ -51,12 +52,11 @@ async function setupOIDC() {
   let client;
   try {
     client = await getOIDCClient();
+    await configureOIDCPassport(client);
+    return true;
   } catch (err) {
     logger.error('Getting OIDC client failed', err);
-  }
-
-  if (client !== null) {
-    await configureOIDCPassport(client);
+    return false;
   }
 }
 

--- a/server/auth/oidc.js
+++ b/server/auth/oidc.js
@@ -1,0 +1,67 @@
+const { Strategy } = require('openid-client');
+const Passport = require('passport');
+
+const logger = require('../logging');
+const Issuer = require('openid-client').Issuer;
+
+const { createUser, parseOpenIDUserinfo } = require('./user');
+
+
+async function getOIDCClient() {
+  const provider = process.env.SDF_OIDC_PROVIDER;
+  const clientId = process.env.SDF_OIDC_CLIENT_ID;
+
+  if (!provider || !clientId) {
+    logger.crit('Did not provide "SDF_OIDC_PROVIDER" and "SDF_OIDC_CLIENT_ID" when using OIDC.');
+  }
+
+  logger.debug('Discovering OIDC issuer.', { provider });
+  let issuer;
+
+  try {
+    issuer = await Issuer.discover(provider);
+    logger.debug('Setting up OIDC issuer', { provider });
+  } catch (err) {
+    logger.error('Discovering issuer failed.', err);
+    return null; // Ugly :'(
+  }
+  return new issuer.Client({ client_id: clientId });
+}
+
+function configureOIDCPassport(client) {
+  const params = {
+    redirect_uri: process.env.SDF_OIDC_REDIRECT_URI,
+    scope: 'openid profile onlineweb4',
+  };
+  const passReqToCallback = false;
+  const usePKCE = false;
+
+  Passport.use('oidc',
+    new Strategy({ client, params, passReqToCallback, usePKCE },
+      async (tokenset, userinfo, done) =>
+        done(null, await createUser(parseOpenIDUserinfo(userinfo)),
+      ),
+    ),
+  );
+
+  logger.info('Successfully set up the OIDC client.');
+}
+
+async function setupOIDC() {
+  let client;
+  try {
+    client = await getOIDCClient();
+  } catch (err) {
+    logger.error('Getting OIDC client failed', err);
+  }
+
+  if (client !== null) {
+    await configureOIDCPassport(client);
+  }
+}
+
+module.exports = {
+  configureOIDCPassport,
+  getOIDCClient,
+  setupOIDC,
+};

--- a/server/auth/providers/__tests__/ow4.js
+++ b/server/auth/providers/__tests__/ow4.js
@@ -1,0 +1,14 @@
+const fetch = require('jest-fetch-mock');
+
+jest.setMock('node-fetch', fetch);
+
+const { getClientInformation } = require('../ow4');
+
+
+describe('ow4 oauth2 provider', () => {
+  it('throws error if it fails', async () => {
+    fetch.mockImplementation(() => { throw Error(); });
+
+    await expect(getClientInformation()).rejects.toEqual(new Error());
+  });
+});

--- a/server/auth/providers/ow4.js
+++ b/server/auth/providers/ow4.js
@@ -37,9 +37,7 @@ passport.use(new OAuth2Strategy(
   },
   async (accessToken, refreshToken, profile, cb) => {
     try {
-      const userInfo = await getClientInformation(accessToken);
-      const user = await createUser(userInfo);
-      return cb(null, user, null);
+      return cb(null, await createUser(await getClientInformation(accessToken)), null);
     } catch (err) {
       return cb(err, null, null);
     }

--- a/server/auth/providers/ow4.js
+++ b/server/auth/providers/ow4.js
@@ -6,22 +6,10 @@ const OAuth2Strategy = require('passport-oauth2');
 const OW4AuthConfig = require('../conf.js').ids;
 const OW4API = require('../conf.js').api;
 
-const addUser = require('../../managers/user').addUser;
-const getUserByUsername = require('../../models/user').getUserByUsername;
-const updateUserById = require('../../models/user').updateUserById;
-const permissions = require('../../../common/auth/permissions');
-const { getActiveGenfors } = require('../../models/meeting');
+const { createUser, parseOW4OAuth2User } = require('../user');
 
-
-function getPermissionLevel(body) {
-  if (body.member) {
-    return permissions.CAN_VOTE;
-  }
-  return permissions.IS_LOGGED_IN;
-}
 
 async function getClientInformation(accessToken) {
-  const genfors = await getActiveGenfors();
   const OW4UserEndpoint = OW4API.backend + OW4API.userEndpoint;
   let body;
   try {
@@ -35,44 +23,7 @@ async function getClientInformation(accessToken) {
     logger.error('Fetching user from resource failed', err);
     throw err;
   }
-  const username = body.username;
-  const fullName = `${body.first_name} ${body.last_name}`;
-  let permissionLevel = getPermissionLevel(body);
-
-  if (!genfors && body.member && body.superuser) {
-    permissionLevel = permissions.IS_SUPERUSER;
-  }
-
-  try {
-    if (!genfors && permissionLevel < permissions.IS_SUPERUSER) {
-      throw new Error('No active genfors');
-    } else if (!genfors && permissionLevel >= permissions.IS_SUPERUSER) {
-      // No genfors and is superuser, probably want to create genfors.
-      logger.info('No active genfors and admin registered. Probably want to create meeting.');
-      return await addUser(fullName, username, permissionLevel);
-    }
-
-    const user = await getUserByUsername(username, genfors);
-    if (user === null) {
-      // Create user if not exists
-      logger.debug('User does not exist -- creating', { username });
-      const newUser = await addUser(fullName, username, permissionLevel);
-      logger.info(`Successfully registered ${newUser.name} for genfors ${newUser.genfors}`,
-        { username, fullName: newUser.name, genfors: newUser.genfors });
-      return newUser;
-    }
-    logger.silly('Fetched existing user, updating.', { username: user.onlinewebId });
-    // Update if user exists
-    const updatedUser = await updateUserById(user._id, { // eslint-disable-line no-underscore-dangle
-      name: fullName,
-      onlinewebId: username,
-      permissions: permissionLevel,
-    });
-    return updatedUser;
-  } catch (err) {
-    logger.error('Updating user failed.', { username, err });
-    throw err;
-  }
+  return parseOW4OAuth2User(body);
 }
 
 passport.use(new OAuth2Strategy(
@@ -84,16 +35,17 @@ passport.use(new OAuth2Strategy(
     callbackURL: OW4AuthConfig.callbackURL,
     scope: OW4AuthConfig.scope,
   },
-  (accessToken, refreshToken, profile, cb) => {
-    getClientInformation(accessToken).then((user) => {
-      cb(null, user, null);
-    }).catch((err) => {
-      cb(err, null, null);
-    });
+  async (accessToken, refreshToken, profile, cb) => {
+    try {
+      const userInfo = await getClientInformation(accessToken);
+      const user = await createUser(userInfo);
+      return cb(null, user, null);
+    } catch (err) {
+      return cb(err, null, null);
+    }
   } // eslint-disable-line comma-dangle
 ));
 
 module.exports = {
   getClientInformation,
-  getPermissionLevel,
 };

--- a/server/auth/user.js
+++ b/server/auth/user.js
@@ -1,0 +1,73 @@
+const logger = require('../logging');
+const permissions = require('../../common/auth/permissions');
+const { getActiveGenfors } = require('../models/meeting');
+const { addUser } = require('../managers/user');
+const { getUserByUsername, updateUserById } = require('../models/user');
+
+function getPermissionLevel(user) {
+  if (user.member) {
+    return permissions.CAN_VOTE;
+  }
+  return permissions.IS_LOGGED_IN;
+}
+
+function parseOW4OAuth2User(data) {
+  const fullName = `${data.first_name} ${data.last_name}`;
+  return {
+    fullName,
+    username: data.username,
+    onlinewebId: data.username,
+    name: fullName,
+    member: data.member,
+    superuser: data.superuser,
+    staff: data.staff,
+  };
+}
+
+async function createUser(user) {
+  const genfors = await getActiveGenfors();
+  const {
+    username,
+    fullName,
+    member,
+    superuser,
+  } = user;
+  const permissionLevel = getPermissionLevel(user);
+
+  try {
+    if (!genfors && member && superuser) {
+      // No genfors and is superuser, probably want to create genfors.
+      logger.info('No active genfors and admin registered. Probably want to create meeting.');
+      return addUser(fullName, username, permissions.IS_SUPERUSER);
+    } else if (!genfors && permissionLevel < permissions.IS_SUPERUSER) {
+      throw new Error('No active genfors');
+    }
+
+    const existingUser = await getUserByUsername(username, genfors);
+    if (existingUser === null) {
+      // Create user if not exists
+      logger.debug('User does not exist -- creating', { username });
+      const newUser = await addUser(fullName, username, permissionLevel);
+      logger.info(`Successfully registered ${newUser.name} for genfors ${newUser.genfors}`,
+        { username, fullName: newUser.name, genfors: newUser.genfors });
+      return newUser;
+    }
+    logger.silly('Fetched existing user, updating.', { username: user.onlinewebId });
+    // Update if user exists
+    const updatedUser = await updateUserById(existingUser._id, {
+      name: fullName,
+      onlinewebId: username,
+      permissions: permissionLevel,
+    });
+    return updatedUser;
+  } catch (err) {
+    logger.error('Updating user failed.', { username, err });
+    throw err;
+  }
+}
+
+module.exports = {
+  createUser,
+  getPermissionLevel,
+  parseOW4OAuth2User,
+};

--- a/server/auth/user.js
+++ b/server/auth/user.js
@@ -24,6 +24,18 @@ function parseOW4OAuth2User(data) {
   };
 }
 
+function parseOpenIDUserinfo(data) {
+  return {
+    fullName: data.name,
+    username: data.preferred_username,
+    onlinewebId: data.preferred_username,
+    name: data.name,
+    member: data.member,
+    superuser: data.superuser,
+    staff: data.staff,
+  };
+}
+
 async function createUser(user) {
   const genfors = await getActiveGenfors();
   const {
@@ -69,5 +81,6 @@ async function createUser(user) {
 module.exports = {
   createUser,
   getPermissionLevel,
+  parseOpenIDUserinfo,
   parseOW4OAuth2User,
 };

--- a/server/utils/generateTestData.js
+++ b/server/utils/generateTestData.js
@@ -80,6 +80,7 @@ function generateOW4OAuth2ResponseBody(data) {
     first_name: 'first name',
     last_name: 'last name',
     username: 'username',
+    preferred_username: 'username',
     email: 'test@example.org',
     member: false,
     staff: false,

--- a/server/utils/generateTestData.js
+++ b/server/utils/generateTestData.js
@@ -75,6 +75,22 @@ const generateVote = data => (Object.assign({
   alternative: '3',
 }, data));
 
+function generateOW4OAuth2ResponseBody(data) {
+  return Object.assign({
+    first_name: 'first name',
+    last_name: 'last name',
+    username: 'username',
+    email: 'test@example.org',
+    member: false,
+    staff: false,
+    superuser: false,
+    nickname: 'nickname',
+    rfid: '12345678',
+    image: '',
+    field_of_study: '',
+  }, data);
+}
+
 module.exports = {
   generateIssue,
   generateSocket,
@@ -84,4 +100,5 @@ module.exports = {
   generateManager,
   generateVote,
   generateAlternative,
+  generateOW4OAuth2ResponseBody,
 };

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -37,7 +37,7 @@ module.exports = merge.smart(config, {
     port,
     proxy: [
       {
-        context: ['/socket.io/', '/login', '/auth', '/logout'],
+        context: ['/socket.io/', '/login', '/auth', '/logout', '/openid-login', '/openid-auth'],
         target: `http://${backendHost}:${backendPort}`,
       },
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@sindresorhus/is@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -967,6 +971,10 @@ base64id@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-1.0.0.tgz#47688cb99bb6804f0e06d3e763b1c32e57d8e6b6"
 
+base64url@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-2.0.0.tgz#eac16e03ea1438eff9423d69baa36262ed1f70bb"
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -1215,6 +1223,18 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
+cacheable-request@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
+  dependencies:
+    clone-response "1.0.2"
+    get-stream "3.0.0"
+    http-cache-semantics "3.8.1"
+    keyv "3.0.0"
+    lowercase-keys "1.0.0"
+    normalize-url "2.0.1"
+    responselike "1.0.2"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -1279,6 +1299,10 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
 caniuse-lite@^1.0.30000748, caniuse-lite@^1.0.30000755:
   version "1.0.30000755"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000755.tgz#9ce5f6e06bd75ec8209abe8853c3beef02248d65"
+
+capture-stack-trace@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -1394,6 +1418,12 @@ cliui@^3.0.3, cliui@^3.2.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
+
+clone-response@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
+  dependencies:
+    mimic-response "^1.0.0"
 
 clone-stats@^0.0.1:
   version "0.0.1"
@@ -1633,6 +1663,12 @@ create-ecdh@^4.0.0:
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
+
+create-error-class@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
+  dependencies:
+    capture-stack-trace "^1.0.0"
 
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.1.3"
@@ -1877,6 +1913,16 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  dependencies:
+    mimic-response "^1.0.0"
+
 deep-diff@^0.3.5:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
@@ -2069,6 +2115,10 @@ domutils@1.5, domutils@1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
+duplexer3@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -2246,6 +2296,10 @@ es6-promise@3.2.1:
 es6-promise@^3.0.2:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
+
+es6-promise@^4.0.5:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
 
 es6-promise@~4.0.3:
   version "4.0.5"
@@ -2880,6 +2934,13 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
+from2@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+
 fs-extra@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
@@ -2955,16 +3016,16 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
+get-stream@3.0.0, get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
 get-stream@^2.0.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
   dependencies:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
-
-get-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -3027,6 +3088,28 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+got@^8.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/got/-/got-8.0.3.tgz#15d038e8101f89e93585d1639d9c49e8a55ae6bc"
+  dependencies:
+    "@sindresorhus/is" "^0.7.0"
+    cacheable-request "^2.1.1"
+    decompress-response "^3.3.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    into-stream "^3.1.0"
+    is-retry-allowed "^1.1.0"
+    isurl "^1.0.0-alpha5"
+    lowercase-keys "^1.0.0"
+    mimic-response "^1.0.0"
+    p-cancelable "^0.3.0"
+    p-timeout "^2.0.1"
+    pify "^3.0.0"
+    safe-buffer "^5.1.1"
+    timed-out "^4.0.1"
+    url-parse-lax "^3.0.0"
+    url-to-options "^1.0.1"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
@@ -3097,6 +3180,16 @@ has-flag@^1.0.0:
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
+has-symbol-support-x@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz#66ec2e377e0c7d7ccedb07a3a84d77510ff1bc4c"
+
+has-to-string-tag-x@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz#a045ab383d7b4b2012a00148ab0aa5f290044d4d"
+  dependencies:
+    has-symbol-support-x "^1.4.1"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -3255,6 +3348,10 @@ htmlparser2@~3.8.1:
     entities "1.0"
     readable-stream "1.1"
 
+http-cache-semantics@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
+
 http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
@@ -3410,6 +3507,13 @@ interpret@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
 
+into-stream@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
+  dependencies:
+    from2 "^2.1.1"
+    p-is-promise "^1.1.0"
+
 invariant@^2.0.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
@@ -3549,6 +3653,10 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+
 is-path-cwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
@@ -3592,6 +3700,10 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
   dependencies:
     tryit "^1.0.1"
+
+is-retry-allowed@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -3710,6 +3822,13 @@ istanbul-reports@^1.1.2:
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.2.tgz#0fb2e3f6aa9922bd3ce45d05d8ab4d5e8e07bd4f"
   dependencies:
     handlebars "^4.0.3"
+
+isurl@^1.0.0-alpha5:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isurl/-/isurl-1.0.0.tgz#b27f4f49f3cdaa3ea44a0a5b7f3462e6edc39d67"
+  dependencies:
+    has-to-string-tag-x "^1.2.0"
+    is-object "^1.0.1"
 
 jest-changed-files@^21.2.0:
   version "21.2.0"
@@ -4033,6 +4152,10 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
+json-buffer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
+
 json-loader@^0.5.4:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
@@ -4101,6 +4224,12 @@ kareem@1.5.0:
 kew@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
+
+keyv@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
+  dependencies:
+    json-buffer "3.0.0"
 
 kind-of@^3.0.2:
   version "3.2.2"
@@ -4204,19 +4333,55 @@ lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
+lodash.assign@^4.0.8:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+
+lodash.clone@^4.3.2:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
 
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.fill@^3.2.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.fill/-/lodash.fill-3.4.0.tgz#a3c74ae640d053adf0dc2079f8720788e8bfef85"
+
+lodash.flatten@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+
+lodash.intersection@^4.1.2:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.intersection/-/lodash.intersection-4.4.0.tgz#0a11ba631d0e95c23c7f2f4cbb9a692ed178e705"
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
-lodash.uniq@^4.5.0:
+lodash.merge@^4.3.5:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
+lodash.omit@^4.2.1:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+
+lodash.partialright@^4.1.3:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.partialright/-/lodash.partialright-4.2.1.tgz#0130d80e83363264d40074f329b8a3e7a8a1cc4b"
+
+lodash.pick@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
+lodash.uniq@^4.2.1, lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
@@ -4224,7 +4389,7 @@ lodash@^3.10.1, lodash@^3.2.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4235,6 +4400,10 @@ lodash@~2.4.1:
 loglevel@^1.4.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.5.1.tgz#189078c94ab9053ee215a0acdbf24244ea0f6502"
+
+long@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -4256,6 +4425,10 @@ loud-rejection@^1.0.0:
 lower-case@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+
+lowercase-keys@1.0.0, lowercase-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
 lru-cache@^4.0.1:
   version "4.1.1"
@@ -4414,6 +4587,10 @@ mime@^1.4.1:
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+
+mimic-response@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
 min-document@^2.19.0:
   version "2.19.0"
@@ -4582,9 +4759,33 @@ node-forge@0.6.33:
   version "0.6.33"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.6.33.tgz#463811879f573d45155ad6a9f43dc296e8e85ebc"
 
+node-forge@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.1.tgz#9da611ea08982f4b94206b3beb4cc9665f20c300"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+
+node-jose@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/node-jose/-/node-jose-0.11.0.tgz#5a737580bc3a39b01ff7938d2398335c458d8587"
+  dependencies:
+    base64url "^2.0.0"
+    es6-promise "^4.0.5"
+    lodash.assign "^4.0.8"
+    lodash.clone "^4.3.2"
+    lodash.fill "^3.2.2"
+    lodash.flatten "^4.2.0"
+    lodash.intersection "^4.1.2"
+    lodash.merge "^4.3.5"
+    lodash.omit "^4.2.1"
+    lodash.partialright "^4.1.3"
+    lodash.pick "^4.2.0"
+    lodash.uniq "^4.2.1"
+    long "^3.1.0"
+    node-forge "^0.7.1"
+    uuid "^3.0.1"
 
 node-libs-browser@^0.7.0:
   version "0.7.0"
@@ -4699,6 +4900,14 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
 
+normalize-url@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-2.0.1.tgz#835a9da1551fa26f70e92329069a23aa6574d7e6"
+  dependencies:
+    prepend-http "^2.0.0"
+    query-string "^5.0.1"
+    sort-keys "^2.0.0"
+
 normalize-url@^1.4.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
@@ -4788,6 +4997,12 @@ obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.1.tgz#104124b6c602c6796881a042541d36db43a5264e"
 
+oidc-token-hash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-2.0.0.tgz#ea1f60db44c78a921268f9f8af37362ac9f6184e"
+  dependencies:
+    base64url "^2.0.0"
+
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
@@ -4807,6 +5022,19 @@ once@^1.3.0, once@^1.3.3, once@^1.4.0:
 onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+
+openid-client@^1.19.3:
+  version "1.19.3"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-1.19.3.tgz#8826fd3e730ec5a4c9c236996b922fe732ffc006"
+  dependencies:
+    base64url "^2.0.0"
+    create-error-class "^3.0.2"
+    got "^8.0.0"
+    lodash "^4.13.1"
+    lru-cache "^4.0.1"
+    node-jose "^0.11.0"
+    oidc-token-hash "^2.0.0"
+    uuid "^3.0.0"
 
 opn@^5.1.0:
   version "5.1.0"
@@ -4883,6 +5111,10 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
+p-is-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
+
 p-limit@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
@@ -4896,6 +5128,12 @@ p-locate@^2.0.0:
 p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+
+p-timeout@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-2.0.1.tgz#d8dd1979595d2dc0139e1fe46b8b646cb3cdf038"
+  dependencies:
+    p-finally "^1.0.0"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -5448,6 +5686,10 @@ prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
+prepend-http@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
+
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
@@ -5557,6 +5799,14 @@ query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
+query-string@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.0.1.tgz#6e2b86fe0e08aef682ecbe86e85834765402bd88"
+  dependencies:
+    decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
@@ -5780,7 +6030,7 @@ readable-stream@2.2.7:
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -6095,6 +6345,12 @@ resolve@^1.1.6, resolve@^1.2.0:
   dependencies:
     path-parse "^1.0.5"
 
+responselike@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
+  dependencies:
+    lowercase-keys "^1.0.0"
+
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
@@ -6381,6 +6637,12 @@ sockjs@0.3.18:
 sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
+  dependencies:
+    is-plain-obj "^1.0.0"
+
+sort-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
   dependencies:
     is-plain-obj "^1.0.0"
 
@@ -6759,7 +7021,7 @@ time-stamp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-2.0.0.tgz#95c6a44530e15ba8d6f4a3ecb8c3a3fac46da357"
 
-timed-out@4.0.1:
+timed-out@4.0.1, timed-out@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
@@ -6956,6 +7218,12 @@ url-loader@^0.5.7:
     loader-utils "^1.0.2"
     mime "1.3.x"
 
+url-parse-lax@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
+  dependencies:
+    prepend-http "^2.0.0"
+
 url-parse@1.0.x:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.0.5.tgz#0854860422afdcfefeb6c965c662d4800169927b"
@@ -6975,6 +7243,10 @@ url-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-3.2.0.tgz#dbad1e0c9e29e105dd0b1f09f6862f7fdb482724"
   dependencies:
     ip-regex "^1.0.1"
+
+url-to-options@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
 
 url@^0.11.0:
   version "0.11.0"
@@ -7026,6 +7298,10 @@ uuid@^2.0.2:
 uuid@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+uuid@^3.0.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This PR does three main things, as explained by each of the commits' messages.

1) 6a97412 makes app setup happen in async functions, so that it is possible to execute asynchronous calls during setup. This is used for automagically discovering an OpenID provider during setup, which is simpler and more prone to change than supplying the values manually.
2) 1d10ed9 simply moves logic from a huge mess of a function to a smaller function (but probably just as messy). Also splits the logic of parsing our custom OAuth2 userinfo and the creation of a user. This has the side effect of making it possible to reuse the create-user function for other authentication methods.
3) 3a6a38b adds and configures OpenID as a new authentication mechanism for the project. Currently there is no client side change, but that can be added at a later stage. The flow is exactly the same as before (click login -> redirect to OW4  ~OAuth2~ OpenID authorization page -> accept -> logged in [notice the change?])

Some new configuration is also required *if* wanting to use OpenID (either instead of or in addition to OAuth2). This configuration consists of setting the address to an OpenID-capable host, supplying the client id for a valid client on the host and a redirect uri. No need to specify where the authorization, token, refresh and logout endpoints are -- they're fetched automatically. To actually activate the OIDC client it is needed to set `SDF_OIDC` to `true`.

💡  Suggestion: Read the diff of each commit on its own, they should have self-explanatory messages and it reduces the scope of the changes.

Resolves #131 