### PR TITLE
Add service worker for caching and better notification support

### DIFF
--- a/client/src/components/Admin/AdminPanel.js
+++ b/client/src/components/Admin/AdminPanel.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { Link, Route, Switch } from 'react-router-dom';
+import * as OfflinePluginRuntime from 'offline-plugin/runtime';
 import { IS_MANAGER } from 'common/auth/permissions';
 import { endGAM, toggleRegistration } from 'features/meeting/actionCreators';
 import AdminHome from './Home';
@@ -35,6 +36,7 @@ class AdminPanel extends React.Component {
       });
     } else if (this.state.currentVersion !== nextProps.version) {
       this.setState({ newVersionAvailable: true });
+      OfflinePluginRuntime.update();
     }
   }
 

--- a/client/src/components/App/index.js
+++ b/client/src/components/App/index.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { Link, Route, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';
+import * as OfflinePluginRuntime from 'offline-plugin/runtime';
 import { IS_MANAGER } from 'common/auth/permissions';
 import { HomeContainer as AppHomeContainer } from './Home';
 import { SetupContainer } from './Setup';
@@ -28,6 +29,7 @@ class App extends React.Component {
       });
     } else if (this.state.currentVersion !== nextProps.version) {
       this.setState({ newVersionAvailable: true });
+      OfflinePluginRuntime.update();
     }
   }
 

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -71,4 +71,9 @@ if (module.hot) {
   });
 }
 
-OfflinePluginRuntime.install();
+OfflinePluginRuntime.install({
+  onUpdateReady: () => {
+    // Tells to new SW to take control immediately
+    OfflinePluginRuntime.applyUpdate();
+  },
+});

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -10,6 +10,7 @@ import 'normalize.css';
 import Raven from 'raven-js';
 import { persistStore, persistCombineReducers } from 'redux-persist';
 import storage from 'redux-persist/es/storage';
+import * as OfflinePluginRuntime from 'offline-plugin/runtime';
 
 import votingApp from './features/reducers';
 import Routes from './routes';
@@ -69,3 +70,5 @@ if (module.hot) {
     render(Routes);
   });
 }
+
+OfflinePluginRuntime.install();

--- a/client/src/utils/notification.js
+++ b/client/src/utils/notification.js
@@ -1,8 +1,29 @@
+function legacyShowNotification(title, options) {
+  // eslint-disable-next-line no-new
+  new Notification(title, options);
+}
+
+async function showNotification(title, options) {
+  let serviceWorkerRunning = false;
+  if ('serviceWorker' in navigator) {
+    try {
+      const registration = await navigator.serviceWorker.getRegistration('sdf');
+      serviceWorkerRunning = registration !== undefined;
+      if (serviceWorkerRunning) {
+        registration.showNotification(title, options);
+      }
+    } catch (err) {
+      serviceWorkerRunning = false;
+    }
+  }
+  if (!serviceWorkerRunning) {
+    legacyShowNotification(title, options);
+  }
+}
+
 export function notify(title) {
   if (Notification.permission === 'granted') {
-    // New is required
-    // eslint-disable-next-line no-new
-    new Notification('En sak har akkurat åpnet for votering', {
+    showNotification('En sak har akkurat åpnet for votering', {
       body: `«${title}»`,
     });
   }
@@ -12,8 +33,7 @@ export function notifyPermission() {
   if (Notification.permission === 'default') {
     Notification.requestPermission((permission) => {
       if (permission === 'granted') {
-        // eslint-disable-next-line no-new
-        new Notification('Varsling er skrudd på', {
+        showNotification('Varsling er skrudd på', {
           body: 'Du vil nå få varsler om nye saker så lenge vinduet er åpent.',
         });
       }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "mongoose": "^4.7.6",
     "node-fetch": "^1.6.3",
     "normalize.css": "^6.0.0",
+    "offline-plugin": "^4.9.0",
     "openid-client": "^1.19.3",
     "passport": "^0.3.2",
     "passport-oauth2": "^1.4.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
+const OfflinePlugin = require('offline-plugin');
 
 const entries = [];
 
@@ -70,5 +71,6 @@ module.exports = {
         module.context && module.context.indexOf('node_modules') !== -1
       ),
     }),
+    new OfflinePlugin({ scope: 'sdf' }),
   ],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,9 @@ module.exports = {
         module.context && module.context.indexOf('node_modules') !== -1
       ),
     }),
-    new OfflinePlugin({ scope: 'sdf' }),
+    new OfflinePlugin({
+      ServiceWorker: { events: true },
+      AppCache: { events: true },
+    }),
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,7 +1941,7 @@ deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
-deep-extend@~0.4.0:
+deep-extend@^0.4.0, deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
@@ -2138,6 +2138,10 @@ ecc-jsbn@~0.1.1:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+ejs@^2.3.4:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
 electron-to-chromium@^1.2.7:
   version "1.3.24"
@@ -4362,7 +4366,7 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@^0.2.11, loader-utils@^0.2.14, loader-utils@^0.2.16:
+loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.14, loader-utils@^0.2.16:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   dependencies:
@@ -5102,6 +5106,16 @@ object.omit@^2.0.0:
 obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.1.tgz#104124b6c602c6796881a042541d36db43a5264e"
+
+offline-plugin@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/offline-plugin/-/offline-plugin-4.9.0.tgz#0874960c0cb0c249f96b7cfc674217934660ed5c"
+  dependencies:
+    deep-extend "^0.4.0"
+    ejs "^2.3.4"
+    loader-utils "0.2.x"
+    minimatch "^3.0.3"
+    slash "^1.0.0"
 
 oidc-token-hash@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
`new Notification` is more or less deprecated and does not work on mobiles. 

Adds a service worker using offline-plugin which automatically caches our webpack assets. When a new version is released the server worker is forced to update. 
Notifications are now created using the service worker and works on Android too with a legacy fallback for browsers without service worker support. 

Fixes #281 