### PR TITLE
Add checkmark after selected button

### DIFF
--- a/client/src/components/Alternatives/Alternative/Alternative.css
+++ b/client/src/components/Alternatives/Alternative/Alternative.css
@@ -22,6 +22,11 @@
   background: #474a6b;
 }
 
+.selected label:after {
+  content: "✓";
+  float: right;
+}
+
 .selected:hover {
   background: #52557a;
 }

--- a/client/src/components/Alternatives/Alternative/Alternative.css
+++ b/client/src/components/Alternatives/Alternative/Alternative.css
@@ -8,6 +8,7 @@
   box-shadow: 0 -2px 0 0 rgba(0, 0, 0, 0.25) inset,
               0 2px 1px 0 rgba(0, 0, 0, 0.2);
   composes: border from "css/border.css";
+  align-items: center;
 }
 
 .alternative:last-of-type {
@@ -22,9 +23,13 @@
   background: #474a6b;
 }
 
-.selected label:after {
+.alternative span {
+    flex-shrink: 1;
+    padding: 1rem;
+}
+
+.selected span:before {
   content: "✓";
-  float: right;
 }
 
 .selected:hover {

--- a/client/src/components/Alternatives/Alternative/index.js
+++ b/client/src/components/Alternatives/Alternative/index.js
@@ -21,6 +21,7 @@ const Alternative = ({ disabled, id, text, selected, onClick }) => {
         />
         {text}
       </label>
+      <span></span>
     </div>
   );
 };

--- a/client/src/components/Alternatives/Alternative/index.js
+++ b/client/src/components/Alternatives/Alternative/index.js
@@ -21,7 +21,9 @@ const Alternative = ({ disabled, id, text, selected, onClick }) => {
         />
         {text}
       </label>
-      <span></span>
+      <span
+          id="checked"
+          />
     </div>
   );
 };

--- a/client/src/components/Alternatives/Alternative/index.js
+++ b/client/src/components/Alternatives/Alternative/index.js
@@ -22,8 +22,8 @@ const Alternative = ({ disabled, id, text, selected, onClick }) => {
         {text}
       </label>
       <span
-          id="checked"
-          />
+        id="checked"
+      />
     </div>
   );
 };


### PR DESCRIPTION
Fixes #234.
Add checkbox after selected button, to indicate that it is selected, therefore montitors with bad contrast can still see what is active/selected.

This image showcases the new checkbox that appears on any selected alternative.
<img width="1313" alt="screen shot 2018-02-14 at 21 18 57" src="https://user-images.githubusercontent.com/31246008/36226029-ed2217e8-11cc-11e8-8056-dcb454182119.png">