### PR TITLE
Display user can vote state

### DIFF
--- a/client/src/components/UserSettings/Permissions.css
+++ b/client/src/components/UserSettings/Permissions.css
@@ -1,0 +1,7 @@
+.card {
+  margin-top: 1rem;
+}
+
+.canNotVote {
+  composes: icon warning from 'css/flaticon.css';
+}

--- a/client/src/components/UserSettings/Permissions.js
+++ b/client/src/components/UserSettings/Permissions.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CAN_VOTE, getPermissionDisplay } from 'common/auth/permissions';
+import Card from '../Card';
+import IconText from '../IconText';
+import css from './Permissions.css';
+
+
+function Permissions({ canVote, permissions }) {
+  const shouldBeAbleToVote = permissions >= CAN_VOTE;
+  return (
+    <Card
+      classes={css.card}
+      title="Rettigheter"
+      corner={shouldBeAbleToVote && !canVote && <IconText iconClass={css.canNotVote} />}
+    >
+      <div>Rettighetsnivå: {getPermissionDisplay(permissions)}</div>
+      {shouldBeAbleToVote &&
+        <div>Stemmeberettiget: {canVote ?
+          'Ja' :
+          <span title="Kontakt tellekorpset for å bli stemmeberettiget.">Nei</span>
+        }
+        </div>
+      }
+    </Card>
+  );
+}
+
+Permissions.defaultProps = {
+  canVote: false,
+  permissions: 0,
+};
+
+Permissions.propTypes = {
+  canVote: PropTypes.bool,
+  permissions: PropTypes.number,
+};
+
+export default Permissions;

--- a/client/src/components/UserSettings/index.js
+++ b/client/src/components/UserSettings/index.js
@@ -11,14 +11,17 @@ import {
   concludedIssueListIsEnabled,
 } from 'features/userSettings/selectors';
 import Button from '../Button';
+import Permissions from './Permissions';
 import css from './UserSettings.css';
 
 const UserSettings = ({
+  canVote,
   concludedIssues,
   notificationsEnabled,
   notificationToggle,
   concludedIssueListEnabled,
   concludedIssueListToggle,
+  permissions,
 }) => (
   <div className={css.component}>
     <Button
@@ -35,14 +38,18 @@ const UserSettings = ({
     >
       {concludedIssueListEnabled ? 'Skjul' : 'Vis'} konkluderte saker
     </Button>}
+    <Permissions canVote={canVote} permissions={permissions} />
   </div>
 );
 
 UserSettings.defaultProps = {
+  canVote: false,
   concludedIssues: {},
+  permissions: 0,
 };
 
 UserSettings.propTypes = {
+  canVote: PropTypes.bool,
   concludedIssues: PropTypes.objectOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
   })),
@@ -50,9 +57,12 @@ UserSettings.propTypes = {
   concludedIssueListToggle: PropTypes.func.isRequired,
   notificationsEnabled: PropTypes.bool.isRequired,
   notificationToggle: PropTypes.func.isRequired,
+  permissions: PropTypes.number,
 };
 
 const mapStateToProps = state => ({
+  canVote: state.auth.canVote,
+  permissions: state.auth.permissions,
   concludedIssues: getConcludedIssuesExceptLatest(state),
   notificationsEnabled: notificationIsEnabled(state),
   concludedIssueListEnabled: concludedIssueListIsEnabled(state),

--- a/client/src/features/auth/reducer.js
+++ b/client/src/features/auth/reducer.js
@@ -1,4 +1,5 @@
 import { ADMIN_SIGNED_IN, AUTH_SIGNED_IN, AUTH_AUTHENTICATED } from 'common/actionTypes/auth';
+import { TOGGLE_CAN_VOTE } from 'common/actionTypes/users';
 
 const defaultState = {
   id: '',
@@ -38,6 +39,16 @@ const auth = (state = defaultState, action) => {
       return {
         ...state,
         reloadPage: true,
+      };
+    }
+
+    case TOGGLE_CAN_VOTE: {
+      if (state.id !== action.data.id) {
+        return state;
+      }
+      return {
+        ...state,
+        canVote: action.data.canVote,
       };
     }
 

--- a/client/src/features/auth/reducer.js
+++ b/client/src/features/auth/reducer.js
@@ -9,6 +9,7 @@ const defaultState = {
   loggedIn: false,
   registered: false,
   authenticated: false,
+  canVote: false,
 };
 
 const auth = (state = defaultState, action) => {
@@ -16,6 +17,7 @@ const auth = (state = defaultState, action) => {
     case AUTH_SIGNED_IN: {
       return {
         ...state,
+        canVote: action.data.canVote,
         username: action.data.username,
         fullName: action.data.full_name,
         loggedIn: true,

--- a/server/channels/__tests__/__snapshots__/connection.js.snap
+++ b/server/channels/__tests__/__snapshots__/connection.js.snap
@@ -15,6 +15,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": true,
         "full_name": "Namy",
         "id": "123",
@@ -307,6 +308,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": true,
         "full_name": "Namy",
         "id": "123",
@@ -353,6 +355,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": true,
         "full_name": "Namy",
         "id": "123",
@@ -572,6 +575,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": true,
         "full_name": "Namy",
         "id": "123",
@@ -716,6 +720,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": true,
         "full_name": "Namy",
         "id": "123",
@@ -808,6 +813,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": true,
         "full_name": "Namy",
         "id": "123",
@@ -1100,6 +1106,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": true,
         "full_name": "Namy",
         "id": "123",
@@ -1146,6 +1153,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": true,
         "full_name": "Namy",
         "id": "123",
@@ -1355,6 +1363,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": true,
         "full_name": "Namy",
         "id": "123",
@@ -1657,6 +1666,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": false,
         "full_name": "Namy",
         "id": "123",
@@ -1703,6 +1713,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": true,
         "full_name": "Namy",
         "id": "123",
@@ -1995,6 +2006,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": false,
         "full_name": "Namy",
         "id": "123",
@@ -2041,6 +2053,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": true,
         "full_name": "Namy",
         "id": "123",
@@ -2337,6 +2350,7 @@ Array [
     "action",
     Object {
       "data": Object {
+        "canVote": true,
         "completedRegistration": true,
         "full_name": "Namy",
         "id": "123",

--- a/server/channels/connection.js
+++ b/server/channels/connection.js
@@ -35,6 +35,7 @@ const emitUserData = async (socket) => {
   emit(socket, VERSION, { version: APP_VERSION });
   const user = await socket.request.user();
   emit(socket, AUTH_SIGNED_IN, {
+    canVote: user.canVote,
     username: user.onlinewebId,
     full_name: user.name,
     id: user.id,


### PR DESCRIPTION
This renders a box with current user permissions. It will vary depending on permissions and voting state.

![image](https://user-images.githubusercontent.com/5422571/36315916-2d450ffc-1339-11e8-9a00-857820f19bcf.png)

Close up:
![image](https://user-images.githubusercontent.com/5422571/36315972-5089df9c-1339-11e8-8ee6-10d14dd74367.png)


Users who should be allowed to vote, but currently can not (canVote is false) gets a warning symbol:
![image](https://user-images.githubusercontent.com/5422571/36315962-48e0c2f6-1339-11e8-9d7a-6ccc228fce66.png)

If you are not allowed to vote at all, some irrelevant information is removed:
![image](https://user-images.githubusercontent.com/5422571/36316007-67c7ec9e-1339-11e8-8dbb-1a9c147ef971.png)

It also works for managers and admins: 
![image](https://user-images.githubusercontent.com/5422571/36316016-6f98d55a-1339-11e8-8bee-5aa88b155d77.png)
