### PR TITLE
Reset lastVotes state when new issue is opened

### DIFF
--- a/client/src/features/lastVotes/reducer.js
+++ b/client/src/features/lastVotes/reducer.js
@@ -1,7 +1,11 @@
+import { OPEN_ISSUE } from 'common/actionTypes/issues';
 import { RECEIVE_VOTE } from 'common/actionTypes/voting';
 
 const lastVotes = (state = [], action) => {
   switch (action.type) {
+    case OPEN_ISSUE: {
+      return [];
+    }
     case RECEIVE_VOTE: {
       return [...state.slice(-5), action.data.id];
     }


### PR DESCRIPTION
Votes from the old issue were still present after a new issue was opened.