### PR TITLE
Explicitly state ordering direction when getting votes for an issue.

### DIFF
--- a/server/models/vote.accessors.js
+++ b/server/models/vote.accessors.js
@@ -8,7 +8,9 @@ function getVotes(question) {
   const issueId = question.id || question;
   return Vote.findAll({
     where: { issueId },
-    order: ['createdAt'],
+    order: [
+      ['createdAt', 'ASC'],
+    ],
   }).map(plainObject);
 }
 


### PR DESCRIPTION
This implements the intended functionality/clarity from
56054c20ec1b4daa56d75e866a4d3e9c49f336f3 by using the proper
syntax, which is an array of tuples and not a simple one dimensional array.