### PR TITLE
Fix missing unit in drone-ssh plugin

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -78,7 +78,7 @@ pipeline:
     port: 22
     username: root
     key: ${SSH_KEY}
-    command_timeout: 600
+    command_timeout: 600s
     when:
       event: tag
       status: success


### PR DESCRIPTION
The `appleboy/drone-ssh` plugin has recently changed and does now require units.

## Description of changes
Add unit, s, to `.drone.yml` file on command_timeout on plugin. Error before fix:

```
could not parse 600 as duration for flag command.timeout,T: time: missing unit in duration 600
```
